### PR TITLE
Added Hint Opacity Dependency Property to TextField

### DIFF
--- a/MaterialDesignColors.WpfExample/TextFields.xaml
+++ b/MaterialDesignColors.WpfExample/TextFields.xaml
@@ -83,7 +83,7 @@
 				 wpf:TextField.Hint="Phone"
 				 />
 		<TextBlock Grid.Row="1" Grid.Column="2" VerticalAlignment="Center" Margin="16 0 8 0">Fruit</TextBlock>
-		<ComboBox Grid.Row="1" Grid.Column="3" wpf:TextField.Hint="Search" IsEditable="True">
+		<ComboBox Grid.Row="1" Grid.Column="3" wpf:TextField.Hint="Search" IsEditable="True" wpf:TextField.HintOpacity=".5">
 			<ComboBoxItem>Apple</ComboBoxItem>
 			<ComboBoxItem>Banana</ComboBoxItem>
 			<ComboBoxItem>Pear</ComboBoxItem>

--- a/MaterialDesignThemes.Wpf/TextField.cs
+++ b/MaterialDesignThemes.Wpf/TextField.cs
@@ -1,69 +1,208 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// MaterialDesignToolkit
+// - TextField.cs
+// --------------------------------------------------------------------
+// Author: Bjarke Søgaard <ekrajb123@gmail.com>
+// Copyright (C) Bjarke Søgaard 2015. All rights reserved.
+
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Navigation;
 
 namespace MaterialDesignThemes.Wpf
 {
-	public static class TextField
-	{
-		public static readonly DependencyProperty TextBoxViewMarginProperty = DependencyProperty.RegisterAttached(
-			"TextBoxViewMargin", typeof (Thickness), typeof (TextField), new PropertyMetadata(new Thickness(double.NegativeInfinity), TextBoxViewMarginPropertyChangedCallback));
+    /// <summary>
+    /// The text field.
+    /// </summary>
+    public static class TextField
+    {
+        #region Static Fields
 
-		private static void TextBoxViewMarginPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
-		{
-			var textBoxBase = dependencyObject as TextBoxBase;
-			if (textBoxBase == null) return;
+        /// <summary>
+        ///     The hint property
+        /// </summary>
+        public static readonly DependencyProperty HintProperty = DependencyProperty.RegisterAttached(
+            "Hint",
+            typeof(string),
+            typeof(TextField),
+            new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.Inherits));
 
-			if (textBoxBase.IsLoaded)
-				ApplyTextBoxViewMargin(textBoxBase, (Thickness)dependencyPropertyChangedEventArgs.NewValue);
+        /// <summary>
+        ///     The text box view margin property
+        /// </summary>
+        public static readonly DependencyProperty TextBoxViewMarginProperty = DependencyProperty.RegisterAttached(
+            "TextBoxViewMargin",
+            typeof(Thickness),
+            typeof(TextField),
+            new PropertyMetadata(new Thickness(double.NegativeInfinity), TextBoxViewMarginPropertyChangedCallback));
 
-			textBoxBase.Loaded += (sender, args) =>
-			{
-				var textBox = (TextBoxBase) sender;
-				ApplyTextBoxViewMargin(textBox, GetTextBoxViewMargin(textBox));
-			};			
+        /// <summary>
+        /// The opacity property
+        /// </summary>
+        public static readonly DependencyProperty HintOpacityProperty = DependencyProperty.RegisterAttached(
+            "HintOpacity",
+            typeof(double),
+            typeof(TextField),
+            new PropertyMetadata(.23, HintOpacityPropertyChangedCallback));
+
+        #endregion
+
+        #region Public Methods and Operators
+
+        /// <summary>
+        /// Gets the hint.
+        /// </summary>
+        /// <param name="element">
+        /// The element.
+        /// </param>
+        /// <returns>
+        /// The <see cref="string"/>.
+        /// </returns>
+        public static string GetHint(DependencyObject element)
+        {
+            return (string)element.GetValue(HintProperty);
+        }
+        
+        /// <summary>
+        /// Gets the text box view margin.
+        /// </summary>
+        /// <param name="element">
+        /// The element.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Thickness"/>.
+        /// </returns>
+        public static Thickness GetTextBoxViewMargin(DependencyObject element)
+        {
+            return (Thickness)element.GetValue(TextBoxViewMarginProperty);
+        }
+        
+        /// <summary>
+        /// Gets the text box view margin.
+        /// </summary>
+        /// <param name="element">
+        /// The element.
+        /// </param>
+        /// <returns>
+        /// The <see cref="Thickness"/>.
+        /// </returns>
+        public static double GetHintOpacityProperty(DependencyObject element)
+        {
+            return (double)element.GetValue(HintOpacityProperty);
         }
 
-		public static void SetTextBoxViewMargin(DependencyObject element, Thickness value)
-		{			
-            element.SetValue(TextBoxViewMarginProperty, value);			
-		}
+        /// <summary>
+        /// Sets the hint.
+        /// </summary>
+        /// <param name="element">
+        /// The element.
+        /// </param>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        public static void SetHint(DependencyObject element, string value)
+        {
+            element.SetValue(HintProperty, value);
+        }
 
-		public static Thickness GetTextBoxViewMargin(DependencyObject element)
-		{
-			return (Thickness) element.GetValue(TextBoxViewMarginProperty);
-		}
+        /// <summary>
+        /// Sets the text box view margin.
+        /// </summary>
+        /// <param name="element">
+        /// The element.
+        /// </param>
+        /// <param name="value">
+        /// The value.
+        /// </param>
+        public static void SetTextBoxViewMargin(DependencyObject element, Thickness value)
+        {
+            element.SetValue(TextBoxViewMarginProperty, value);
+        }
 
-		private static void ApplyTextBoxViewMargin(TextBoxBase textBox, Thickness margin)
-		{
-			if (margin.Equals(new Thickness(double.NegativeInfinity))) return;
+        public static void SetHintOpacity(DependencyObject element, double value)
+        {
+            element.SetValue(HintOpacityProperty, value);
+        }
 
-			var scrollViewer = textBox.Template.FindName("PART_ContentHost", textBox) as ScrollViewer;
-			if (scrollViewer == null) return;
-			var frameworkElement = scrollViewer.Content as FrameworkElement;
+        #endregion
 
-			//remove nice new sytax until i get appveyor working	
-			//var frameworkElement = (textBox.Template.FindName("PART_ContentHost", textBox) as ScrollViewer)?.Content as FrameworkElement;
-			if (frameworkElement != null)
-				frameworkElement.Margin = margin;
-		}
+        #region Methods
 
-		public static readonly DependencyProperty HintProperty = DependencyProperty.RegisterAttached(
-			"Hint", typeof (string), typeof (TextField), new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.Inherits));
+        /// <summary>
+        /// Applies the text box view margin.
+        /// </summary>
+        /// <param name="textBox">
+        /// The text box.
+        /// </param>
+        /// <param name="margin">
+        /// The margin.
+        /// </param>
+        private static void ApplyTextBoxViewMargin(TextBoxBase textBox, Thickness margin)
+        {
+            if (margin.Equals(new Thickness(double.NegativeInfinity)))
+            {
+                return;
+            }
 
-		public static void SetHint(DependencyObject element, string value)
-		{
-			element.SetValue(HintProperty, value);
-		}
+            var scrollViewer = textBox.Template.FindName("PART_ContentHost", textBox) as ScrollViewer;
+            if (scrollViewer == null)
+            {
+                return;
+            }
 
-		public static string GetHint(DependencyObject element)
-		{
-			return (string) element.GetValue(HintProperty);
-		}
-	}
+            var frameworkElement = scrollViewer.Content as FrameworkElement;
+
+            // remove nice new sytax until i get appveyor working	
+            // var frameworkElement = (textBox.Template.FindName("PART_ContentHost", textBox) as ScrollViewer)?.Content as FrameworkElement;
+            if (frameworkElement != null)
+            {
+                frameworkElement.Margin = margin;
+            }
+        }
+
+        /// <summary>
+        /// The text box view margin property changed callback.
+        /// </summary>
+        /// <param name="dependencyObject">
+        /// The dependency object.
+        /// </param>
+        /// <param name="dependencyPropertyChangedEventArgs">
+        /// The dependency property changed event args.
+        /// </param>
+        private static void TextBoxViewMarginPropertyChangedCallback(
+            DependencyObject dependencyObject,
+            DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            var textBoxBase = dependencyObject as TextBoxBase;
+            if (textBoxBase == null)
+            {
+                return;
+            }
+
+            if (textBoxBase.IsLoaded)
+            {
+                ApplyTextBoxViewMargin(textBoxBase, (Thickness)dependencyPropertyChangedEventArgs.NewValue);
+            }
+
+            textBoxBase.Loaded += (sender, args) =>
+            {
+                var textBox = (TextBoxBase)sender;
+                ApplyTextBoxViewMargin(textBox, GetTextBoxViewMargin(textBox));
+            };
+        }
+
+        private static void HintOpacityPropertyChangedCallback(
+            DependencyObject dependencyObject,
+            DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+        {
+            var textBoxBase = dependencyObject as TextBoxBase;
+            if (textBoxBase == null)
+            {
+                return;
+            }
+
+            textBoxBase.Opacity = (double)dependencyPropertyChangedEventArgs.NewValue;
+        }
+
+        #endregion
+    }
 }

--- a/MaterialDesignThemes.Wpf/TextField.cs
+++ b/MaterialDesignThemes.Wpf/TextField.cs
@@ -18,7 +18,7 @@ namespace MaterialDesignThemes.Wpf
         #region Static Fields
 
         /// <summary>
-        ///     The hint property
+        /// The hint property
         /// </summary>
         public static readonly DependencyProperty HintProperty = DependencyProperty.RegisterAttached(
             "Hint",
@@ -27,7 +27,7 @@ namespace MaterialDesignThemes.Wpf
             new FrameworkPropertyMetadata(default(string), FrameworkPropertyMetadataOptions.Inherits));
 
         /// <summary>
-        ///     The text box view margin property
+        /// The text box view margin property
         /// </summary>
         public static readonly DependencyProperty TextBoxViewMarginProperty = DependencyProperty.RegisterAttached(
             "TextBoxViewMargin",
@@ -36,7 +36,7 @@ namespace MaterialDesignThemes.Wpf
             new PropertyMetadata(new Thickness(double.NegativeInfinity), TextBoxViewMarginPropertyChangedCallback));
 
         /// <summary>
-        /// The opacity property
+        /// The hint opacity property
         /// </summary>
         public static readonly DependencyProperty HintOpacityProperty = DependencyProperty.RegisterAttached(
             "HintOpacity",
@@ -51,39 +51,33 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Gets the hint.
         /// </summary>
-        /// <param name="element">
-        /// The element.
-        /// </param>
+        /// <param name="element">The element.</param>
         /// <returns>
-        /// The <see cref="string"/>.
+        /// The <see cref="string" />.
         /// </returns>
         public static string GetHint(DependencyObject element)
         {
             return (string)element.GetValue(HintProperty);
         }
-        
+
         /// <summary>
         /// Gets the text box view margin.
         /// </summary>
-        /// <param name="element">
-        /// The element.
-        /// </param>
+        /// <param name="element">The element.</param>
         /// <returns>
-        /// The <see cref="Thickness"/>.
+        /// The <see cref="Thickness" />.
         /// </returns>
         public static Thickness GetTextBoxViewMargin(DependencyObject element)
         {
             return (Thickness)element.GetValue(TextBoxViewMarginProperty);
         }
-        
+
         /// <summary>
         /// Gets the text box view margin.
         /// </summary>
-        /// <param name="element">
-        /// The element.
-        /// </param>
+        /// <param name="element">The element.</param>
         /// <returns>
-        /// The <see cref="Thickness"/>.
+        /// The <see cref="Thickness" />.
         /// </returns>
         public static double GetHintOpacityProperty(DependencyObject element)
         {
@@ -93,12 +87,8 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Sets the hint.
         /// </summary>
-        /// <param name="element">
-        /// The element.
-        /// </param>
-        /// <param name="value">
-        /// The value.
-        /// </param>
+        /// <param name="element">The element.</param>
+        /// <param name="value">The value.</param>
         public static void SetHint(DependencyObject element, string value)
         {
             element.SetValue(HintProperty, value);
@@ -107,17 +97,18 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Sets the text box view margin.
         /// </summary>
-        /// <param name="element">
-        /// The element.
-        /// </param>
-        /// <param name="value">
-        /// The value.
-        /// </param>
+        /// <param name="element">The element.</param>
+        /// <param name="value">The value.</param>
         public static void SetTextBoxViewMargin(DependencyObject element, Thickness value)
         {
             element.SetValue(TextBoxViewMarginProperty, value);
         }
 
+        /// <summary>
+        /// Sets the hint opacity.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="value">The value.</param>
         public static void SetHintOpacity(DependencyObject element, double value)
         {
             element.SetValue(HintOpacityProperty, value);
@@ -130,12 +121,8 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Applies the text box view margin.
         /// </summary>
-        /// <param name="textBox">
-        /// The text box.
-        /// </param>
-        /// <param name="margin">
-        /// The margin.
-        /// </param>
+        /// <param name="textBox">The text box.</param>
+        /// <param name="margin">The margin.</param>
         private static void ApplyTextBoxViewMargin(TextBoxBase textBox, Thickness margin)
         {
             if (margin.Equals(new Thickness(double.NegativeInfinity)))
@@ -162,12 +149,8 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// The text box view margin property changed callback.
         /// </summary>
-        /// <param name="dependencyObject">
-        /// The dependency object.
-        /// </param>
-        /// <param name="dependencyPropertyChangedEventArgs">
-        /// The dependency property changed event args.
-        /// </param>
+        /// <param name="dependencyObject">The dependency object.</param>
+        /// <param name="dependencyPropertyChangedEventArgs">The dependency property changed event args.</param>
         private static void TextBoxViewMarginPropertyChangedCallback(
             DependencyObject dependencyObject,
             DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
@@ -190,6 +173,11 @@ namespace MaterialDesignThemes.Wpf
             };
         }
 
+        /// <summary>
+        /// Hints the opacity property changed callback.
+        /// </summary>
+        /// <param name="dependencyObject">The dependency object.</param>
+        /// <param name="dependencyPropertyChangedEventArgs">The <see cref="DependencyPropertyChangedEventArgs" /> instance containing the event data.</param>
         private static void HintOpacityPropertyChangedCallback(
             DependencyObject dependencyObject,
             DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -178,7 +178,7 @@
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Opacity=".23"
+                            Opacity="{Binding Path=(wpf:TextField.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
                             IsHitTestVisible="False"
                             Text="{TemplateBinding wpf:TextField.Hint}"
                             Visibility="{TemplateBinding Text, Converter={StaticResource TextFieldHintVisibilityConverter}}" />
@@ -261,7 +261,7 @@
                             Margin="{TemplateBinding Padding}"
                             HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                            Opacity=".23"
+                            Opacity="{Binding Path=(wpf:TextField.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"
                             Text="{TemplateBinding wpf:TextField.Hint}"
                             IsHitTestVisible="False"
                             Visibility="{TemplateBinding Text, Converter={StaticResource TextFieldHintVisibilityConverter}}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -39,7 +39,7 @@
                             <TextBlock Text="{Binding Path=(wpf:TextField.Hint), RelativeSource={RelativeSource TemplatedParent}}"
 											   Visibility="{TemplateBinding Text, Converter={StaticResource TextFieldHintVisibilityConverter}}"
 											   x:Name="Hint"
-											   Opacity=".23"/>
+											   Opacity="{Binding Path=(wpf:TextField.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>
                         </Grid>
                     </Border>
                     <ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -46,7 +46,7 @@
 								<TextBlock Text="{Binding Path=(wpf:TextField.Hint), RelativeSource={RelativeSource TemplatedParent}}"
 										   Visibility="{TemplateBinding Text, Converter={StaticResource TextFieldHintVisibilityConverter}}"
 										   x:Name="Hint"
-										   Opacity=".23"/>
+										   Opacity="{Binding Path=(wpf:TextField.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>
 							</Grid>
 						</ControlTemplate>
 						<ControlTemplate x:Key="DropDownButtonTemplate" TargetType="{x:Type Button}">


### PR DESCRIPTION
Added a Hint Opacity Dependency Property to TextField which allows specifying of opacity on the Hint text.
Standard value is still 0.23 as usual.

The Fruit Combobox is using 0.5 hint opacity to demonstrate the property.