### PR TITLE
Shadows usage

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -30,11 +30,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Border Background="{TemplateBinding Background}">
-                            <Border.Effect>
-                                <DropShadowEffect BlurRadius="5" ShadowDepth="1" Direction="270" Color="#CCCCCC" />
-                            </Border.Effect>
-                        </Border>
+                        <Border Background="{TemplateBinding Background}" Effect="{DynamicResource MaterialDesignShadowDepth1}" />
                         <Border Background="{TemplateBinding Background}" x:Name="border" CornerRadius="2">
                             <wpf:VisualFeedbackContentControl Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"                                                               
                                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
@@ -131,12 +127,8 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}"
-                                 x:Name="border">
-                            <Ellipse.Effect>
-                                <DropShadowEffect BlurRadius="5" ShadowDepth="1" Direction="270" Color="#CCCCCC"/>
-                            </Ellipse.Effect>
-                        </Ellipse>
+                        <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}" Effect="{DynamicResource MaterialDesignShadowDepth1}"
+                                 x:Name="border" />
                         <wpf:VisualFeedbackContentControl Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"                                                               
                                                           Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}" ClipToBounds="True"
                                                           HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -3,15 +3,11 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
 
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
-    </ResourceDictionary.MergedDictionaries>
-
     <converters:CardClipConverter x:Key="CardClipConverter" />
 
     <ControlTemplate TargetType="{x:Type wpf:Card}" x:Key="CardTemplate">
         <Border Margin="{TemplateBinding Margin}"
-                Effect="{StaticResource MaterialDesignShadowDepth2}"
+                Effect="{DynamicResource MaterialDesignShadowDepth2}"
                 CornerRadius="{TemplateBinding UniformCornerRadius}" Background="Transparent">
             <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
                     x:Name="PART_ClipBorder"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -154,10 +154,7 @@
 			<Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
 				<Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2"
                                     MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}"
-                                    BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}">
-					<Border.Effect>
-						<DropShadowEffect BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="Black" Opacity=".23"/>
-					</Border.Effect>
+                                    BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}" Effect="{DynamicResource MaterialDesignShadowDepth2}">
 					<Border x:Name="dropDownBorder" Background="Transparent">
 						<ScrollViewer x:Name="DropDownScrollViewer">
 							<Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
@@ -240,10 +237,7 @@
 			<Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
 				<Border x:Name="dropDownBorder" BorderBrush="{DynamicResource MaterialDesignDivider}" BorderThickness="1" Background="{DynamicResource MaterialDesignPaper}"
                                 CornerRadius="2"
-                                MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}">
-					<Border.Effect>
-						<DropShadowEffect BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="Black" Opacity=".23"/>
-					</Border.Effect>
+                                MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}" Effect="{DynamicResource MaterialDesignShadowDepth2}">
 					<ScrollViewer x:Name="DropDownScrollViewer">
 						<Grid x:Name="grid" RenderOptions.ClearTypeHint="Enabled">
 							<Canvas x:Name="canvas" HorizontalAlignment="Left" Height="0" VerticalAlignment="Top" Width="0">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -14,5 +14,11 @@
     
     <SolidColorBrush x:Key="MaterialDesignDivider" Color="#616161" />
     <SolidColorBrush x:Key="MaterialDesignSelection" Color="#757575" />
-    
+
+    <Color x:Key="MaterialDesignShadow1">#CCCCCC</Color>
+    <Color x:Key="MaterialDesignShadow2">#C4C4C4</Color>
+    <Color x:Key="MaterialDesignShadow3">#BBBBBB</Color>
+    <Color x:Key="MaterialDesignShadow4">#BBBBBB</Color>
+    <Color x:Key="MaterialDesignShadow5">#BBBBBB</Color>
+
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -4,7 +4,6 @@
 
 	<ResourceDictionary.MergedDictionaries>
 		<ResourceDictionary Source="MaterialDesignTheme.Calendar.xaml" />
-		<ResourceDictionary Source="MaterialDesignTheme.Shadows.xaml" />
 	</ResourceDictionary.MergedDictionaries>
 
 	<Style x:Key="MaterialDesignDatePickerTextBox" TargetType="{x:Type DatePickerTextBox}">
@@ -67,7 +66,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type Calendar}">
-					<Border Effect="{StaticResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
+					<Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
 						<CalendarItem x:Name="PART_CalendarItem" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" Style="{DynamicResource MaterialDesignCalendarItemPortrait}"
 									  />	
 					</Border>					

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -4,6 +4,7 @@
     <!-- use this resource dictionary to set up the most common themese for standard controls -->
     
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.button.xaml" />
 		<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.calendar.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.checkbox.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -14,4 +14,10 @@
     <SolidColorBrush x:Key="MaterialDesignDivider" Color="#eeeeee" />
     <SolidColorBrush x:Key="MaterialDesignSelection" Color="#e0e0e0" />
 
+    <Color x:Key="MaterialDesignShadow1">#CCCCCC</Color>
+    <Color x:Key="MaterialDesignShadow2">#C4C4C4</Color>
+    <Color x:Key="MaterialDesignShadow3">#BBBBBB</Color>
+    <Color x:Key="MaterialDesignShadow4">#BBBBBB</Color>
+    <Color x:Key="MaterialDesignShadow5">#BBBBBB</Color>
+
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -92,11 +92,7 @@
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
                     <Grid>
                         <Border CornerRadius="2"
-                                Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true">
-                            <Border.Effect>
-                                <DropShadowEffect BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="Black" Opacity=".23"/>
-                            </Border.Effect>                                
-                        </Border>
+                                Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true" Effect="{DynamicResource MaterialDesignShadowDepth2}" />
                         <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                         <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Padding="{TemplateBinding Padding}" SnapsToDevicePixels="true"
                                 CornerRadius="2"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -4,7 +4,7 @@
 	<!--  thanks: http://marcangers.com/material-design-shadows-in-wpf/ -->
 	
 	<DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="#CCCCCC"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="2.5" Direction="270" Color="#BBBBBB"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="#C4C4C4"/>
     <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="#BBBBBB"/>
     <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="#BBBBBB"/>
     <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="#BBBBBB"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -3,10 +3,10 @@
     
 	<!--  thanks: http://marcangers.com/material-design-shadows-in-wpf/ -->
 	
-	<DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="#CCCCCC"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="#C4C4C4"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="#BBBBBB"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="#BBBBBB"/>
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="#BBBBBB"/>
+	<DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="{DynamicResource MaterialDesignShadow1}"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="{DynamicResource MaterialDesignShadow2}"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="{DynamicResource MaterialDesignShadow3}"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="{DynamicResource MaterialDesignShadow4}"/>
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{DynamicResource MaterialDesignShadow5}"/>
 	
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -3,10 +3,6 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
 
-	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
-	</ResourceDictionary.MergedDictionaries>
-	
 	<converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
 	
 	<Style x:Key="MaterialDesignTimePicker" TargetType="{x:Type wpf:TimePicker}">
@@ -25,7 +21,7 @@
 						<Setter Property="Template">
 							<Setter.Value>
 								<ControlTemplate TargetType="{x:Type ContentControl}">
-									<Border Effect="{StaticResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
+									<Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
 										<ContentPresenter Content="{TemplateBinding ContentControl.Content}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
 									</Border>
 								</ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -171,7 +171,7 @@
 					<Viewbox Width="34">
 						<Grid>
 							<Rectangle x:Name="Track" Fill="Black" HorizontalAlignment="Left" Height="15" Margin="4.211,5,-4.211,0" Stroke="{x:Null}" VerticalAlignment="Top" Width="40" RadiusY="7.5" RadiusX="7.5" Opacity="0.26"/>
-							<Ellipse x:Name="Thumb" Fill="#FFFAFAFA" HorizontalAlignment="Left" Height="25" Margin="0,0,0,0" Stroke="{x:Null}" VerticalAlignment="Top" Width="25" RenderTransformOrigin="0.5,0.5">
+							<Ellipse x:Name="Thumb" Fill="#FFFAFAFA" HorizontalAlignment="Left" Height="25" Margin="0,0,0,0" Stroke="{x:Null}" VerticalAlignment="Top" Width="25" RenderTransformOrigin="0.5,0.5" Effect="{DynamicResource MaterialDesignShadowDepth1}">
 								<Ellipse.RenderTransform>
 									<TransformGroup>
 										<ScaleTransform/>
@@ -180,9 +180,6 @@
 										<TranslateTransform/>
 									</TransformGroup>
 								</Ellipse.RenderTransform>
-								<Ellipse.Effect>
-									<DropShadowEffect BlurRadius="5" ShadowDepth="1" Direction="270" Color="#CCCCCC"/>
-								</Ellipse.Effect>
 							</Ellipse>
 						</Grid>
 					</Viewbox>


### PR DESCRIPTION
- use MaterialDesignShadowDepth1 and MaterialDesignShadowDepth2, so it's easier to override
- move the shadows resource dictionary to the defaults rd
- create shadow color keys in dark and light rd (the colors are still the same, can be your part @ButchersBoy )
