### PR TITLE
Fix 'TemplateRoot' name cannot be found in the name scope of 'System.Windows.Controls.ControlTemplate'

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -69,9 +69,11 @@
                         </Grid>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <EventTrigger RoutedEvent="FrameworkElement.Loaded">
-                            <BeginStoryboard Storyboard="{StaticResource OnLoaded}"/>
-                        </EventTrigger>
+                        <Trigger Property="IsVisible" Value="True">
+                            <Trigger.EnterActions>
+                                <BeginStoryboard Storyboard="{StaticResource OnLoaded}"/>
+                            </Trigger.EnterActions>
+                        </Trigger>
                         <Trigger Property="Orientation" Value="Vertical">
                             <Setter Property="LayoutTransform" TargetName="TemplateRoot">
                                 <Setter.Value>


### PR DESCRIPTION
If we use the ProgressBar (style) in a TabControl we can get a nasty exception like this:

```'TemplateRoot' name cannot be found in the name scope of 'System.Windows.Controls.ControlTemplate'```

This can happen if the Loaded event comes before ApplyTemplate, so the Storyboard can't find the TargetName.

Found this while playing with OnePlus-One and this issue https://github.com/Droidkit/OnePlus-One/issues/2