### PR TITLE
Popup Validationerrortemplate and ShowOnFocus

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/BooleanToVisibilityConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/BooleanToVisibilityConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class BooleanToVisibilityConverter : IValueConverter
+    {
+        public Visibility TrueValue { get; set; }
+        public Visibility FalseValue { get; set; }
+
+        public object Convert(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            if (value is Boolean)
+                return (Boolean)value ? TrueValue : FalseValue;
+
+            if (parameter is Boolean)
+                return (Boolean)parameter ? TrueValue : FalseValue;
+
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            if (Equals(value, TrueValue))
+                return true;
+
+            if (Equals(value, FalseValue))
+                return false;
+
+            if (Equals(parameter, TrueValue))
+                return true;
+
+            if (Equals(parameter, FalseValue))
+                return false;
+
+            return null;
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/CustomValidationPopup.cs
+++ b/MaterialDesignThemes.Wpf/CustomValidationPopup.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+
+namespace MaterialDesignThemes.Wpf
+{
+    /// <summary>
+    /// MahApp's validation popup copy
+    /// </summary>
+    public sealed class CustomValidationPopup : Popup
+    {
+        private Window _hostWindow;
+
+        public CustomValidationPopup()
+        {
+            this.Loaded += this.CustomValidationPopup_Loaded;
+            this.Opened += this.CustomValidationPopup_Opened;
+        }
+
+        protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            this.IsOpen = false;
+        }
+
+        private void CustomValidationPopup_Loaded(object sender, RoutedEventArgs e)
+        {
+            var target = this.PlacementTarget as FrameworkElement;
+            if (target == null)
+            {
+                return;
+            }
+
+            this._hostWindow = Window.GetWindow(target);
+            if (this._hostWindow == null)
+            {
+                return;
+            }
+
+            this._hostWindow.LocationChanged -= this.hostWindow_SizeOrLocationChanged;
+            this._hostWindow.LocationChanged += this.hostWindow_SizeOrLocationChanged;
+            this._hostWindow.SizeChanged -= this.hostWindow_SizeOrLocationChanged;
+            this._hostWindow.SizeChanged += this.hostWindow_SizeOrLocationChanged;
+            target.SizeChanged -= this.hostWindow_SizeOrLocationChanged;
+            target.SizeChanged += this.hostWindow_SizeOrLocationChanged;
+            this._hostWindow.StateChanged -= this.hostWindow_StateChanged;
+            this._hostWindow.StateChanged += this.hostWindow_StateChanged;
+            this._hostWindow.Activated -= this.hostWindow_Activated;
+            this._hostWindow.Activated += this.hostWindow_Activated;
+            this._hostWindow.Deactivated -= this.hostWindow_Deactivated;
+            this._hostWindow.Deactivated += this.hostWindow_Deactivated;
+
+            this.Unloaded -= this.CustomValidationPopup_Unloaded;
+            this.Unloaded += this.CustomValidationPopup_Unloaded;
+        }
+
+        private void CustomValidationPopup_Opened(object sender, EventArgs e)
+        {
+            //this.SetTopmostState(true);
+        }
+
+        private void hostWindow_Activated(object sender, EventArgs e)
+        {
+            //this.SetTopmostState(true);
+        }
+
+        private void hostWindow_Deactivated(object sender, EventArgs e)
+        {
+            //this.SetTopmostState(false);
+        }
+
+        private void CustomValidationPopup_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var target = this.PlacementTarget as FrameworkElement;
+            if (target != null)
+            {
+                target.SizeChanged -= this.hostWindow_SizeOrLocationChanged;
+            }
+            if (this._hostWindow != null)
+            {
+                this._hostWindow.LocationChanged -= this.hostWindow_SizeOrLocationChanged;
+                this._hostWindow.SizeChanged -= this.hostWindow_SizeOrLocationChanged;
+                this._hostWindow.StateChanged -= this.hostWindow_StateChanged;
+                this._hostWindow.Activated -= this.hostWindow_Activated;
+                this._hostWindow.Deactivated -= this.hostWindow_Deactivated;
+            }
+            this.Unloaded -= this.CustomValidationPopup_Unloaded;
+            this.Opened -= this.CustomValidationPopup_Opened;
+            this._hostWindow = null;
+        }
+
+        private void hostWindow_StateChanged(object sender, EventArgs e)
+        {
+            if (this._hostWindow != null && this._hostWindow.WindowState != WindowState.Minimized)
+            {
+                var target = this.PlacementTarget as FrameworkElement;
+                var holder = target != null ? target.DataContext as AdornedElementPlaceholder : null;
+                if (holder != null && holder.AdornedElement != null)
+                {
+                    var errorTemplate = holder.AdornedElement.GetValue(Validation.ErrorTemplateProperty);
+                    holder.AdornedElement.SetValue(Validation.ErrorTemplateProperty, null);
+                    holder.AdornedElement.SetValue(Validation.ErrorTemplateProperty, errorTemplate);
+                }
+            }
+        }
+
+        private void hostWindow_SizeOrLocationChanged(object sender, EventArgs e)
+        {
+            var offset = this.HorizontalOffset;
+            // "bump" the offset to cause the popup to reposition itself on its own
+            this.HorizontalOffset = offset + 1;
+            this.HorizontalOffset = offset;
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -188,6 +188,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Themes\MaterialDesignTheme.ValidationErrorTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Card.cs" />
@@ -210,6 +214,7 @@
     <Compile Include="Converters\NotZeroToVisibilityConverter.cs" />
     <Compile Include="Converters\SizeToRectConverter.cs" />
     <Compile Include="CustomPopupPlacementCallbackHelper.cs" />
+    <Compile Include="CustomValidationPopup.cs" />
     <Compile Include="DataGridAssist.cs" />
     <Compile Include="DateTimeEx.cs" />
     <Compile Include="ListSortDirectionIndicator.cs" />
@@ -241,6 +246,7 @@
     <Compile Include="ToolTipAssist.cs" />
     <Compile Include="RippleAssist.cs" />
     <Compile Include="Ripple.cs" />
+    <Compile Include="ValidationAssist.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -275,6 +281,7 @@
       <Name>MaterialDesignColors.Wpf</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -199,6 +199,7 @@
     <Compile Include="ClockChoiceMadeEventArgs.cs" />
     <Compile Include="ClockItemButton.cs" />
     <Compile Include="ColorZone.cs" />
+    <Compile Include="Converters\BooleanToVisibilityConverter.cs" />
     <Compile Include="Converters\BrushToRadialGradientBrushConverter.cs" />
     <Compile Include="Converters\CalendarDateCoalesceConverter.cs" />
     <Compile Include="Converters\CircularProgressBar\ArcEndPointConverter.cs" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -4,6 +4,9 @@
     
     <!-- plan is to add all of the light/dark specific brushes, quite granular at first. can then consolodate any repition later on if necessary -->
 
+    <Color x:Key="ValidationErrorColor">#f44336</Color>
+    <SolidColorBrush x:Key="ValidationErrorBrush" Color="{StaticResource ValidationErrorColor}"/>
+    
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FF000000"/>
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FF37474f"/>        
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DDFFFFFF"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -2,8 +2,9 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     
     <!-- use this resource dictionary to set up the most common themese for standard controls -->
-    
+
     <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.button.xaml" />
 		<ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.calendar.xaml" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -1,7 +1,9 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    
+
     <!-- plan is to add all of the light/dark specific brushes, quite granular at first. can then consolodate any repition later on if necessary -->
+    <Color x:Key="ValidationErrorColor">#f44336</Color>
+    <SolidColorBrush x:Key="ValidationErrorBrush" Color="{StaticResource ValidationErrorColor}"/>
 
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FFFFFFFF"/>
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FFfafafa"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -5,6 +5,8 @@
 
     <converters:TextFieldHintVisibilityConverter x:Key="TextFieldHintVisibilityConverter" />
 
+
+
     <Style x:Key="MaterialDesignTextBox" TargetType="{x:Type TextBox}">
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignTextBoxBorder}" />
@@ -19,16 +21,7 @@
         <Setter Property="AllowDrop" Value="true"/>        
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
         <Setter Property="Stylus.IsFlicksEnabled" Value="False"/>
-        <Setter Property="Validation.ErrorTemplate">
-            <Setter.Value>
-                <ControlTemplate>
-                    <StackPanel>
-                        <AdornedElementPlaceholder />
-                        <TextBlock FontSize="10" Foreground="#f44336" Text="{Binding Path=[0].ErrorContent}" />
-                    </StackPanel>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Validation.ErrorTemplate" Value="{DynamicResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
@@ -58,7 +51,7 @@
                             <Setter Property="BorderBrush"  Value="{DynamicResource PrimaryHueMidBrush}"/>
                         </Trigger>
                         <Trigger Property="Validation.HasError" Value="true">
-                            <Setter Property="BorderBrush" Value="#f44336"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -163,7 +156,7 @@
                             <Setter Property="BorderBrush"  Value="{DynamicResource PrimaryHueMidBrush}"/>
                         </Trigger>
                         <Trigger Property="Validation.HasError" Value="true">
-                            <Setter Property="BorderBrush" Value="#f44336"/>
+                            <Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -1,0 +1,34 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
+
+    <ControlTemplate x:Key="MaterialDesignValidationErrorTemplate">
+        <StackPanel>
+            <AdornedElementPlaceholder Name="Placeholder" />
+            <wpf:CustomValidationPopup x:Name="ValidationPopup"
+                                       IsOpen="True"
+                                       Placement="Bottom" PlacementTarget="{Binding ElementName=Placeholder}"
+                                       AllowsTransparency="True">
+                <Border Background="{DynamicResource MaterialDesignPaper}">
+                    <Border.Resources>
+                        <DataTemplate DataType="{x:Type ValidationError}">
+                            <TextBlock Foreground="{DynamicResource ValidationErrorBrush}"
+                                       FontSize="10"
+                                       MaxWidth="250"
+                                       Margin="2"
+                                       TextWrapping="Wrap"
+                                       Text="{Binding ErrorContent}"
+                                       UseLayoutRounding="false" />
+                        </DataTemplate>
+                    </Border.Resources>
+                    <ContentPresenter Content="{Binding CurrentItem}" />
+                </Border>
+            </wpf:CustomValidationPopup>
+        </StackPanel>
+        <ControlTemplate.Triggers>
+            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True">
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}"/>
+            </DataTrigger>
+        </ControlTemplate.Triggers>
+    </ControlTemplate>
+</ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -1,33 +1,69 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
-
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
+    <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
+    
     <ControlTemplate x:Key="MaterialDesignValidationErrorTemplate">
-        <StackPanel>
-            <AdornedElementPlaceholder Name="Placeholder" />
-            <wpf:CustomValidationPopup x:Name="ValidationPopup"
-                                       IsOpen="True"
-                                       Placement="Bottom" PlacementTarget="{Binding ElementName=Placeholder}"
-                                       AllowsTransparency="True">
-                <Border Background="{DynamicResource MaterialDesignPaper}">
-                    <Border.Resources>
-                        <DataTemplate DataType="{x:Type ValidationError}">
-                            <TextBlock Foreground="{DynamicResource ValidationErrorBrush}"
+        <ControlTemplate.Resources>
+            <DataTemplate DataType="{x:Type ValidationError}">
+                <TextBlock Foreground="{DynamicResource ValidationErrorBrush}"
                                        FontSize="10"
                                        MaxWidth="250"
                                        Margin="2"
                                        TextWrapping="Wrap"
                                        Text="{Binding ErrorContent}"
                                        UseLayoutRounding="false" />
-                        </DataTemplate>
-                    </Border.Resources>
+            </DataTemplate>
+        </ControlTemplate.Resources>
+        <StackPanel>
+            <AdornedElementPlaceholder Name="Placeholder" />
+            <Border Name="DefaultErrorViewerWrapper"
+                        Visibility="Collapsed">
+                <Border Name="DefaultErrorViewer"
+                        Background="{DynamicResource MaterialDesignPaper}">
+                    <ContentPresenter Content="{Binding CurrentItem}" />
+                </Border>
+            </Border>
+
+            <wpf:CustomValidationPopup x:Name="ValidationPopup"
+                                       IsOpen="False"
+                                       Placement="Bottom" PlacementTarget="{Binding ElementName=Placeholder}"
+                                       AllowsTransparency="True">
+                <Border Background="{DynamicResource MaterialDesignPaper}">
                     <ContentPresenter Content="{Binding CurrentItem}" />
                 </Border>
             </wpf:CustomValidationPopup>
         </StackPanel>
         <ControlTemplate.Triggers>
-            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True">
-                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}"/>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="True"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter TargetName="ValidationPopup" Property="IsOpen"
+                        Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter TargetName="DefaultErrorViewer" Property="Visibility"
+                        Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+            
+            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="True">
+                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True"/>
+            </DataTrigger>
+            
+            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False">
+                <Setter TargetName="DefaultErrorViewerWrapper" Property="Visibility" Value="Visible"/>
             </DataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -3,7 +3,7 @@
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
                     xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
     <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed"/>
-    
+
     <ControlTemplate x:Key="MaterialDesignValidationErrorTemplate">
         <ControlTemplate.Resources>
             <DataTemplate DataType="{x:Type ValidationError}">
@@ -18,12 +18,10 @@
         </ControlTemplate.Resources>
         <StackPanel>
             <AdornedElementPlaceholder Name="Placeholder" />
-            <Border Name="DefaultErrorViewerWrapper"
-                        Visibility="Collapsed">
-                <Border Name="DefaultErrorViewer"
-                        Background="{DynamicResource MaterialDesignPaper}">
-                    <ContentPresenter Content="{Binding CurrentItem}" />
-                </Border>
+            <Border Name="DefaultErrorViewer"
+                    Visibility="Collapsed"
+                    Background="{DynamicResource MaterialDesignPaper}">
+                <ContentPresenter Content="{Binding CurrentItem}" />
             </Border>
 
             <wpf:CustomValidationPopup x:Name="ValidationPopup"
@@ -38,33 +36,45 @@
         <ControlTemplate.Triggers>
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.OnlyShowOnFocus)}" Value="False"/>
                     <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="True"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
-                    <Setter TargetName="ValidationPopup" Property="IsOpen"
-                        Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}"/>
+                    <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
 
             <MultiDataTrigger>
                 <MultiDataTrigger.Conditions>
-                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.ShowOnFocus)}" Value="True"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.OnlyShowOnFocus)}" Value="False"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter TargetName="DefaultErrorViewer" Property="Visibility" Value="Visible"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.OnlyShowOnFocus)}" Value="True"/>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="True"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter TargetName="ValidationPopup" Property="IsOpen"
+                            Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay}"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
+
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.OnlyShowOnFocus)}" Value="True"/>
                     <Condition Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False"/>
                 </MultiDataTrigger.Conditions>
                 <MultiDataTrigger.Setters>
                     <Setter TargetName="DefaultErrorViewer" Property="Visibility"
-                        Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
+                            Value="{Binding ElementName=Placeholder, Path=AdornedElement.IsKeyboardFocusWithin, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                 </MultiDataTrigger.Setters>
             </MultiDataTrigger>
-            
-            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="True">
-                <Setter TargetName="ValidationPopup" Property="IsOpen" Value="True"/>
-            </DataTrigger>
-            
-            <DataTrigger Binding="{Binding ElementName=Placeholder, Path=AdornedElement.(wpf:ValidationAssist.UsePopup)}" Value="False">
-                <Setter TargetName="DefaultErrorViewerWrapper" Property="Visibility" Value="Visible"/>
-            </DataTrigger>
         </ControlTemplate.Triggers>
     </ControlTemplate>
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace MaterialDesignThemes.Wpf
+{
+    public static class ValidationAssist
+    {
+        #region ShowOnFocusProperty
+
+        /// <summary>
+        /// The hint property
+        /// </summary>
+        public static readonly DependencyProperty ShowOnFocusProperty = DependencyProperty.RegisterAttached(
+            "ShowOnFocus",
+            typeof(bool),
+            typeof(ValidationAssist),
+            new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static bool GetShowOnFocus(DependencyObject element)
+        {
+            return (bool) element.GetValue(ShowOnFocusProperty);
+        }
+
+        public static void SetShowOnFocus(DependencyObject element, bool value)
+        {
+            element.SetValue(ShowOnFocusProperty, value);
+        }
+
+        #endregion
+    }
+}

--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -31,5 +31,28 @@ namespace MaterialDesignThemes.Wpf
         }
 
         #endregion
+
+        #region UsePopupProperty
+
+        /// <summary>
+        /// The hint property
+        /// </summary>
+        public static readonly DependencyProperty UsePopupProperty = DependencyProperty.RegisterAttached(
+            "UsePopup",
+            typeof(bool),
+            typeof(ValidationAssist),
+            new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
+
+        public static bool GetUsePopup(DependencyObject element)
+        {
+            return (bool)element.GetValue(ShowOnFocusProperty);
+        }
+
+        public static void SetUsePopup(DependencyObject element, bool value)
+        {
+            element.SetValue(ShowOnFocusProperty, value);
+        }
+
+        #endregion
     }
 }

--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -14,20 +14,20 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// The hint property
         /// </summary>
-        public static readonly DependencyProperty ShowOnFocusProperty = DependencyProperty.RegisterAttached(
-            "ShowOnFocus",
+        public static readonly DependencyProperty OnlyShowOnFocusProperty = DependencyProperty.RegisterAttached(
+            "OnlyShowOnFocus",
             typeof(bool),
             typeof(ValidationAssist),
             new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.Inherits));
 
-        public static bool GetShowOnFocus(DependencyObject element)
+        public static bool GetOnlyShowOnFocus(DependencyObject element)
         {
-            return (bool) element.GetValue(ShowOnFocusProperty);
+            return (bool)element.GetValue(OnlyShowOnFocusProperty);
         }
 
-        public static void SetShowOnFocus(DependencyObject element, bool value)
+        public static void SetOnlyShowOnFocus(DependencyObject element, bool value)
         {
-            element.SetValue(ShowOnFocusProperty, value);
+            element.SetValue(OnlyShowOnFocusProperty, value);
         }
 
         #endregion
@@ -45,12 +45,12 @@ namespace MaterialDesignThemes.Wpf
 
         public static bool GetUsePopup(DependencyObject element)
         {
-            return (bool)element.GetValue(ShowOnFocusProperty);
+            return (bool)element.GetValue(OnlyShowOnFocusProperty);
         }
 
         public static void SetUsePopup(DependencyObject element, bool value)
         {
-            element.SetValue(ShowOnFocusProperty, value);
+            element.SetValue(OnlyShowOnFocusProperty, value);
         }
 
         #endregion


### PR DESCRIPTION
Added validationerrortemplate (a copy from MahApps), that can popup over the
window.
Also, added ValidationAssist.ShowOnFocus attached property that allows ValidationError is showed only when textbox in focus (in case when exists a few textbox in error state, they show validation errors that mixed with themselves). 

Before:
![before](https://cloud.githubusercontent.com/assets/5460448/10095969/6066157c-6376-11e5-87c6-5026271437c3.png)
After:
![after](https://cloud.githubusercontent.com/assets/5460448/10095971/65252602-6376-11e5-8e3d-f7877aa6f702.png)
