### PR TITLE
Very small fix of floating hint

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -130,6 +130,7 @@
                             <TextBlock Text="{Binding Path=(wpf:TextFieldAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
                                        FontSize="{TemplateBinding FontSize}"
                                        HorizontalAlignment="Left"
+                                       VerticalAlignment="Top"
                                        x:Name="Hint"
                                        Margin="1 0 1 0"
                                        Opacity="{Binding Path=(wpf:TextFieldAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}"/>


### PR DESCRIPTION
Small fix of selecting text under the floating hint in textbox.

Description of problem:
When you double clicked (or trying to select with mouse) a text under
hint in textbox, nothing happens.