### PR TITLE
Fix compilation errors with App.xaml

### DIFF
--- a/MainDemo.Wpf/App.xaml
+++ b/MainDemo.Wpf/App.xaml
@@ -11,8 +11,8 @@
                 <!-- Material -->
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/MaterialDesignColor.Lime.xaml" />
 
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>


### PR DESCRIPTION
New user here. I copy-pasted the code from `App.xaml` like the README said, and while the first 2 lines worked fine, I got compiler errors on the others. Decompiling the assemblies with ILSpy shows that there are no `Recommended`, `Accent`, or `Primary` directories in `MaterialDesignColors`:

![xamlbug](https://cloud.githubusercontent.com/assets/9159214/10266289/66c70e9c-6a26-11e5-9058-3fd45e620e1f.PNG)

So now I removed the extra directories and everything's good.

This should save other users a lot of headache.