### PR TITLE
Fix DataGrid Checkbox selection

### DIFF
--- a/MainDemo.Wpf/Grids.xaml
+++ b/MainDemo.Wpf/Grids.xaml
@@ -20,7 +20,7 @@
             <DataGrid Margin="0 8 0 0" ItemsSource="{Binding Items3}" CanUserSortColumns="True" CanUserAddRows="False" AutoGenerateColumns="False"
                       wpf:DataGridAssist.CellPadding="13 8 8 8" wpf:DataGridAssist.ColumnHeaderPadding="8">
                 <DataGrid.Columns>
-                    <DataGridCheckBoxColumn Binding="{Binding IsSelected}" 
+                    <DataGridCheckBoxColumn Binding="{Binding IsSelected, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged}" 
                                                 ElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnStyle}"
                                                 EditingElementStyle="{StaticResource MaterialDesignDataGridCheckBoxColumnEditingStyle}">
                         <DataGridCheckBoxColumn.Header>

--- a/MainDemo.Wpf/Grids.xaml
+++ b/MainDemo.Wpf/Grids.xaml
@@ -69,11 +69,12 @@
                 </DataGrid.Columns>
             </DataGrid>
             <TextBlock Margin="0 24 0 0">Auto Generated Columns</TextBlock>
-            <DataGrid  Margin="0 8 0 0" ItemsSource="{Binding Items3}" CanUserSortColumns="True" CanUserAddRows="False" />
+            <DataGrid  Margin="0 8 0 0" ItemsSource="{Binding Items3}" CanUserSortColumns="True" CanUserAddRows="False" AutoGeneratingColumn="DataGrid_OnAutoGeneratingColumn" />
             <TextBlock Margin="0 24 0 0">Custom Padding</TextBlock>
             <DataGrid  Margin="0 8 0 0" ItemsSource="{Binding Items3}" CanUserSortColumns="True" CanUserAddRows="False"
-                       wpf:DataGridAssist.CellPadding="4 2 2 2" wpf:DataGridAssist.ColumnHeaderPadding="4 2 2 2"
-                       />
+                       wpf:DataGridAssist.CellPadding="4 2 2 2"
+                       wpf:DataGridAssist.ColumnHeaderPadding="4 2 2 2"
+                       AutoGeneratingColumn="DataGrid_OnAutoGeneratingColumn" />
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/MainDemo.Wpf/Grids.xaml.cs
+++ b/MainDemo.Wpf/Grids.xaml.cs
@@ -24,5 +24,19 @@ namespace MaterialDesignColors.WpfExample
         {
             InitializeComponent();
         }
+
+        private void DataGrid_OnAutoGeneratingColumn(object sender, DataGridAutoGeneratingColumnEventArgs e)
+        {
+            DataGridCheckBoxColumn column = e.Column as DataGridCheckBoxColumn;
+            if (column != null)
+            {
+                var binding = column.Binding as Binding;
+                if (binding != null)
+                {
+                    binding.NotifyOnTargetUpdated = true;
+                    binding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
+                }
+            }
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -15,7 +15,7 @@
 
     <Style x:Key="MaterialDesignDataGridCheckBoxColumnStyle" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignCheckBox}">
         <Setter Property="HorizontalAlignment" Value="Center" />
-        <Setter Property="IsHitTestVisible" Value="False" />
+        <Setter Property="IsHitTestVisible" Value="True" />
         <Setter Property="Focusable" Value="False" />
     </Style>
 


### PR DESCRIPTION
This Fixes #100 DataGrid checkbox selection issue.

first fix set `IsHitTestVisible` to true

```xaml
<Style x:Key="MaterialDesignDataGridCheckBoxColumnStyle" TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignCheckBox}">
        <Setter Property="HorizontalAlignment" Value="Center" />
        <Setter Property="IsHitTestVisible" Value="True" />
        <Setter Property="Focusable" Value="False" />
</Style>
```

second fix inspired by http://stackoverflow.com/a/19048262/920384

```xaml
<DataGridCheckBoxColumn Binding="{Binding IsSelected, NotifyOnTargetUpdated=True, UpdateSourceTrigger=PropertyChanged}"
```

for auto generated columns, this must be handled by the user itself...

```xaml
<DataGrid  Margin="0 8 0 0"
            ItemsSource="{Binding Items3}"
            CanUserSortColumns="True"
            CanUserAddRows="False"
            AutoGeneratingColumn="DataGrid_OnAutoGeneratingColumn" />
```

```csharp
private void DataGrid_OnAutoGeneratingColumn(object sender, DataGridAutoGeneratingColumnEventArgs e)
{
    DataGridCheckBoxColumn column = e.Column as DataGridCheckBoxColumn;
    if (column != null)
    {
        var binding = column.Binding as Binding;
        if (binding != null)
        {
            binding.NotifyOnTargetUpdated = true;
            binding.UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged;
        }
    }
}
```

![2015-10-17 17h14_58](https://cloud.githubusercontent.com/assets/658431/10559524/b97e7b6c-74f2-11e5-9b23-ec8f7193d89e.gif)
