### PR TITLE
Added custom xaml namespace

### DIFF
--- a/MaterialDesignColors.Wpf/Properties/AssemblyInfo.cs
+++ b/MaterialDesignColors.Wpf/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Windows.Markup;
 [assembly: AssemblyCopyright("Copyright © 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/colors", "MaterialDesignColors.Wpf")]
+[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/colors", "materialDesignColor")]
 [assembly: XmlnsDefinition("http://materialdesigninxaml.net/winfx/xaml/colors", "MaterialDesignColors.Wpf")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/MaterialDesignColors.Wpf/Properties/AssemblyInfo.cs
+++ b/MaterialDesignColors.Wpf/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Markup;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,6 +16,8 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/colors", "MaterialDesignColors.Wpf")]
+[assembly: XmlnsDefinition("http://materialdesigninxaml.net/winfx/xaml/colors", "MaterialDesignColors.Wpf")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
+++ b/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Windows.Markup;
 [assembly: AssemblyCopyright("Copyright © 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/themes", "MaterialDesignThemes.Wpf")]
+[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/themes", "materialDesignTheme")]
 [assembly: XmlnsDefinition("http://materialdesigninxaml.net/winfx/xaml/themes", "MaterialDesignThemes.Wpf")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
+++ b/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
@@ -16,7 +16,7 @@ using System.Windows.Markup;
 [assembly: AssemblyCopyright("Copyright © 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/themes", "materialDesignTheme")]
+[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/themes", "materialDesign")]
 [assembly: XmlnsDefinition("http://materialdesigninxaml.net/winfx/xaml/themes", "MaterialDesignThemes.Wpf")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
+++ b/MaterialDesignThemes.Wpf/Properties/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Markup;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -15,7 +16,8 @@ using System.Windows;
 [assembly: AssemblyCopyright("Copyright © 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
+[assembly: XmlnsPrefix("http://materialdesigninxaml.net/winfx/xaml/themes", "MaterialDesignThemes.Wpf")]
+[assembly: XmlnsDefinition("http://materialdesigninxaml.net/winfx/xaml/themes", "MaterialDesignThemes.Wpf")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Just a small simple addition , a custom xaml namespace like how mahapps has http://metro.mahapps.com/winfx/xaml/controls. 
The custom namespace is http://materialdesigninxaml.net/winfx/xaml/themes for Material Design Themes and http://materialdesigninxaml.net/winfx/xaml/colors for Material Design Colors.

This addition makes code simpler and shorter

Users can still use the old clr-namespace thingy if they like, so it won't break anything ![emoji](https://cloud.githubusercontent.com/assets/13938848/11120817/492ee014-8978-11e5-86fb-0ba75bcb5b0b.png)

![lil painted dog](https://cloud.githubusercontent.com/assets/13938848/11120944/1ba725d8-8979-11e5-8161-09ef3acf79b2.png)
SuicSoft