### PR TITLE
Add blackout styles to calendar

### DIFF
--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -19,8 +19,10 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <TextBlock Grid.ColumnSpan="3">Classic WPF DatePicker control with Material Design theme, and new TimePicker control:</TextBlock>
-        <DatePicker Grid.Row="1" Grid.Column="0" Width="100" HorizontalAlignment="Left" Margin="0 16 0 0"
-                    materialDesign:TextFieldAssist.Hint="Pick Date"/>
+        <StackPanel Grid.Row="1" Grid.Column="0">
+            <DatePicker Width="100" HorizontalAlignment="Left" Margin="0 16 0 0" materialDesign:TextFieldAssist.Hint="Pick Date" />
+            <DatePicker x:Name="FutureDatePicker" Width="100" HorizontalAlignment="Left" Margin="0 16 0 0" materialDesign:TextFieldAssist.Hint="Future Date" />
+        </StackPanel>
         <materialDesign:TimePicker Grid.Row="1" Grid.Column="1"  VerticalAlignment="Top"  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0"
                         materialDesign:TextFieldAssist.Hint="Custom hint" />
         <materialDesign:TimePicker Grid.Row="1" Grid.Column="2"  Is24Hours="True" x:Name="PresetTimePicker" VerticalAlignment="Top"  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0" />                                

--- a/MainDemo.Wpf/Pickers.xaml.cs
+++ b/MainDemo.Wpf/Pickers.xaml.cs
@@ -24,6 +24,7 @@ namespace MaterialDesignColors.WpfExample
         public Pickers()
         {
             InitializeComponent();
+            FutureDatePicker.BlackoutDates.AddDatesInPast();
         }
 
         public void CalendarDialogOpenedEventHandler(object sender, DialogOpenedEventArgs eventArgs)

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -226,7 +226,7 @@
                                 <VisualState x:Name="Active"/>
                                 <VisualState x:Name="Inactive">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.2" Storyboard.TargetProperty="Opacity"/>
+                                        <DoubleAnimation Duration="0" To="0.35" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -251,7 +251,7 @@
                                 <VisualState x:Name="NormalDay"/>
                                 <VisualState x:Name="BlackoutDay">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To=".2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="Blackout"/>
+                                        <DoubleAnimation Duration="0" To="0.2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="Blackout"/>
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -262,12 +262,14 @@
                         <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" />
                         <ContentPresenter x:Name="NormalText" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="5,1,5,1" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
                         <Path x:Name="Blackout"
-                              Data="M8.1772461,11.029181 L10.433105,11.029181 L11.700684,12.801641 L12.973633,11.029181 L15.191895,11.029181 L12.844727,13.999395 L15.21875,17.060919 L12.962891,17.060919 L11.673828,15.256231 L10.352539,17.060919 L8.1396484,17.060919 L10.519043,14.042364 z"
-                              Fill="#FF000000"
-                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                              Data="M 16 0 l -16 16"
+                              StrokeThickness="1.5" 
+                              Stroke="#FF000000"
+                              HorizontalAlignment="Stretch"
+                              VerticalAlignment="Stretch" 
                               Margin="3"
-                              Opacity="0"
-                              RenderTransformOrigin="0.5,0.5"
+                              Opacity="0" 
+                              RenderTransformOrigin="0.5,0.5" 
                               Stretch="Fill"/>
                         <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1"/>
                     </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -89,56 +89,40 @@
                                 <VisualState x:Name="Active"/>
                                 <VisualState x:Name="Inactive" />
                             </VisualStateGroup>
-                            <VisualStateGroup x:Name="DayStates">
-                                <VisualStateGroup.Transitions>
-                                    <VisualTransition GeneratedDuration="0"/>
-                                </VisualStateGroup.Transitions>
-                                <VisualState x:Name="RegularDay"/>
-                                <VisualState x:Name="Today">
-                                    <Storyboard>
-                                        <DoubleAnimation Duration="0" To="1" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="TodayBackground"/>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(TextElement.Foreground)" Storyboard.TargetName="NormalText">
-                                            <DiscreteObjectKeyFrame Value="{DynamicResource PrimaryHueLightForegroundBrush}" KeyTime="0" />
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="BlackoutDayStates">
-                                <VisualStateGroup.Transitions>
-                                    <VisualTransition GeneratedDuration="0"/>
-                                </VisualStateGroup.Transitions>
-                                <VisualState x:Name="NormalDay"/>
-                                <VisualState x:Name="BlackoutDay">
-                                    <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="HighlightingBorder" />
-                                        <DoubleAnimation Duration="0" To="0.38" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText" />
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Ellipse x:Name="TodayBackground" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity="0" />
-                        <Ellipse x:Name="SelectedBackground" Fill="{DynamicResource PrimaryHueMidBrush}" Opacity="0" />
-                        <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" />
-                        <Border x:Name="HighlightingBorder" Opacity="1">
-                            <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" />
-                        </Border>
-                        <ContentPresenter x:Name="NormalText" 
-                                          TextElement.Foreground="{TemplateBinding Foreground}" 
+                        <Ellipse x:Name="TodayBackground"
+                                 Fill="{DynamicResource PrimaryHueLightBrush}"
+                                 Opacity="0" />
+                        <Ellipse x:Name="SelectedBackground"
+                                 Fill="{DynamicResource PrimaryHueMidBrush}"
+                                 Opacity="0" />
+                        <Border BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Background="{TemplateBinding Background}" />
+                        <Ellipse x:Name="HighlightBackground"
+                                 Fill="{DynamicResource PrimaryHueDarkBrush}"
+                                 Opacity="0" />
+                        <ContentPresenter x:Name="NormalText"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          Margin="5,1,5,1" 
+                                          Margin="5,1,5,1"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                        <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1" />
+                        <Ellipse x:Name="DayButtonFocusVisual"
+                                 Stroke="{DynamicResource PrimaryHueDarkBrush}"
+                                 Opacity="0"
+                                 Visibility="Collapsed"
+                                 StrokeThickness="1" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsInactive" Value="True">
-                <Setter Property="MinHeight" Value="0" />
-                <Setter Property="MaxHeight" Value="0" />
-            </Trigger>
-            <Trigger Property="IsBlackedOut" Value="True">
-                <Setter Property="Cursor" Value="No" />
+            <Trigger Property="IsInactive"
+                     Value="True">
+                <Setter Property="MinHeight"
+                        Value="0" />
+                <Setter Property="MaxHeight"
+                        Value="0" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -261,25 +245,47 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Ellipse x:Name="TodayBackground" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity="0" />
-                        <Ellipse x:Name="SelectedBackground" Fill="{DynamicResource PrimaryHueMidBrush}" Opacity="0" />
-                        <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}"/>
-                        <Border x:Name="HighlightingBorder" Opacity="1">
-                            <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0"/>
+                        <Ellipse x:Name="TodayBackground"
+                                 Fill="{DynamicResource PrimaryHueLightBrush}"
+                                 Opacity="0" />
+                        <Ellipse x:Name="SelectedBackground"
+                                 Fill="{DynamicResource PrimaryHueMidBrush}"
+                                 Opacity="0" />
+                        <Border BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Background="{TemplateBinding Background}"/>
+                        <Border x:Name="HighlightingBorder"
+                                Opacity="1">
+                            <Ellipse x:Name="HighlightBackground"
+                                     Fill="{DynamicResource PrimaryHueDarkBrush}"
+                                     Opacity="0"/>
                         </Border>
-                        <ContentPresenter x:Name="NormalText" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="5,1,5,1" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                        <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1"/>
+                        <ContentPresenter x:Name="NormalText"
+                                          TextElement.Foreground="{TemplateBinding Foreground}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          Margin="5,1,5,1"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                        <Ellipse x:Name="DayButtonFocusVisual"
+                                 Stroke="{DynamicResource PrimaryHueDarkBrush}"
+                                 Opacity="0"
+                                 Visibility="Collapsed"
+                                 StrokeThickness="1"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsInactive" Value="True">
-                <Setter Property="MinHeight" Value="0" />
-                <Setter Property="MaxHeight" Value="0" />
+            <Trigger Property="IsInactive"
+                     Value="True">
+                <Setter Property="MinHeight"
+                        Value="0" />
+                <Setter Property="MaxHeight"
+                        Value="0" />
             </Trigger>
-            <Trigger Property="IsBlackedOut" Value="True">
-                <Setter Property="Cursor" Value="No" />
+            <Trigger Property="IsBlackedOut"
+                     Value="True">
+                <Setter Property="Cursor"
+                        Value="No" />
             </Trigger>
         </Style.Triggers>
     </Style>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -7,6 +7,7 @@
         <Setter Property="MinWidth" Value="5"/>
         <Setter Property="MinHeight" Value="5"/>
         <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Cursor" Value="Hand"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Margin" Value="2"/>
         <Setter Property="Width" Value="48" />
@@ -86,11 +87,7 @@
                                     <VisualTransition GeneratedDuration="0"/>
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Active"/>
-                                <VisualState x:Name="Inactive">
-                                    <Storyboard>
-                                        <!--ColorAnimation Duration="0" To="#FF777777" Storyboard.TargetProperty="(TextElement.Foreground).(SolidColorBrush.Color)" Storyboard.TargetName="NormalText"/-->
-                                    </Storyboard>
-                                </VisualState>
+                                <VisualState x:Name="Inactive" />
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="DayStates">
                                 <VisualStateGroup.Transitions>
@@ -113,39 +110,44 @@
                                 <VisualState x:Name="NormalDay"/>
                                 <VisualState x:Name="BlackoutDay">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To=".2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="Blackout"/>
+                                        <DoubleAnimation Duration="0" To="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="HighlightingBorder" />
+                                        <DoubleAnimation Duration="0" To="0.38" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                         <Ellipse x:Name="TodayBackground" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity="0" />
                         <Ellipse x:Name="SelectedBackground" Fill="{DynamicResource PrimaryHueMidBrush}" Opacity="0" />
-                        <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}"/>
-                        <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" />
-                        <ContentPresenter x:Name="NormalText"
-                                          TextElement.Foreground="{TemplateBinding Foreground}"
+                        <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" />
+                        <Border x:Name="HighlightingBorder" Opacity="1">
+                            <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" />
+                        </Border>
+                        <ContentPresenter x:Name="NormalText" 
+                                          TextElement.Foreground="{TemplateBinding Foreground}" 
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          Margin="5,1,5,1"
+                                          Margin="5,1,5,1" 
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                        <Path x:Name="Blackout"
-                              Fill="#FF000000"
-                              HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                              Margin="3"
-                              Opacity="0"
-                              RenderTransformOrigin="0.5,0.5"
-                              Stretch="Fill"
-                              Data="M8.1772461,11.029181 L10.433105,11.029181 L11.700684,12.801641 L12.973633,11.029181 L15.191895,11.029181 L12.844727,13.999395 L15.21875,17.060919 L12.962891,17.060919 L11.673828,15.256231 L10.352539,17.060919 L8.1396484,17.060919 L10.519043,14.042364 z" />
-                        <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1"/>
+                        <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsInactive" Value="True">
+                <Setter Property="MinHeight" Value="0" />
+                <Setter Property="MaxHeight" Value="0" />
+            </Trigger>
+            <Trigger Property="IsBlackedOut" Value="True">
+                <Setter Property="Cursor" Value="No" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="MaterialDesignCalendarDayButton" TargetType="{x:Type CalendarDayButton}">
         <Setter Property="MinWidth" Value="5"/>
         <Setter Property="MinHeight" Value="5"/>
         <Setter Property="FontSize" Value="12"/>
+        <Setter Property="Cursor" Value="Hand" />
         <Setter Property="Margin" Value="2"/>
         <Setter Property="Width" Value="34" />
         <Setter Property="Height" Value="34" />
@@ -224,11 +226,7 @@
                                     <VisualTransition GeneratedDuration="0"/>
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Active"/>
-                                <VisualState x:Name="Inactive">
-                                    <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.35" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText"/>
-                                    </Storyboard>
-                                </VisualState>
+                                <VisualState x:Name="Inactive"/>
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="DayStates">
                                 <VisualStateGroup.Transitions>
@@ -251,7 +249,14 @@
                                 <VisualState x:Name="NormalDay"/>
                                 <VisualState x:Name="BlackoutDay">
                                     <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0.2" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="Blackout"/>
+                                        <DoubleAnimation Duration="0"
+                                                         To="0"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         Storyboard.TargetName="HighlightingBorder"/>
+                                        <DoubleAnimation Duration="0"
+                                                         To="0.38"
+                                                         Storyboard.TargetProperty="Opacity" 
+                                                         Storyboard.TargetName="NormalText" />
                                     </Storyboard>
                                 </VisualState>
                             </VisualStateGroup>
@@ -259,23 +264,24 @@
                         <Ellipse x:Name="TodayBackground" Fill="{DynamicResource PrimaryHueLightBrush}" Opacity="0" />
                         <Ellipse x:Name="SelectedBackground" Fill="{DynamicResource PrimaryHueMidBrush}" Opacity="0" />
                         <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}"/>
-                        <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" />
-                        <ContentPresenter x:Name="NormalText" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="5,1,5,1" VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
-                        <Path x:Name="Blackout"
-                              Data="M 16 0 l -16 16"
-                              StrokeThickness="1.5" 
-                              Stroke="#FF000000"
-                              HorizontalAlignment="Stretch"
-                              VerticalAlignment="Stretch" 
-                              Margin="3"
-                              Opacity="0" 
-                              RenderTransformOrigin="0.5,0.5" 
-                              Stretch="Fill"/>
+                        <Border x:Name="HighlightingBorder" Opacity="1">
+                            <Ellipse x:Name="HighlightBackground" Fill="{DynamicResource PrimaryHueDarkBrush}" Opacity="0"/>
+                        </Border>
+                        <ContentPresenter x:Name="NormalText" TextElement.Foreground="{TemplateBinding Foreground}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="5,1,5,1" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
                         <Ellipse x:Name="DayButtonFocusVisual" Stroke="{DynamicResource PrimaryHueDarkBrush}" Opacity="0" Visibility="Collapsed" StrokeThickness="1"/>
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsInactive" Value="True">
+                <Setter Property="MinHeight" Value="0" />
+                <Setter Property="MaxHeight" Value="0" />
+            </Trigger>
+            <Trigger Property="IsBlackedOut" Value="True">
+                <Setter Property="Cursor" Value="No" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style x:Key="MaterialDesignCalendarItemPortrait" TargetType="{x:Type CalendarItem}">
@@ -433,7 +439,7 @@
                                             <TranslateTransform X="0"/>
                                         </Border.RenderTransform>
                                     </Border>
-                                    <Grid x:Name="PART_MonthView" RenderTransformOrigin="0, 0.5">
+                                    <Grid x:Name="PART_MonthView" RenderTransformOrigin="0, 0.5" MinHeight="254">
                                         <Grid.RenderTransform>
                                             <TranslateTransform X="0" />
                                         </Grid.RenderTransform>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -439,7 +439,7 @@
                                             <TranslateTransform X="0"/>
                                         </Border.RenderTransform>
                                     </Border>
-                                    <Grid x:Name="PART_MonthView" RenderTransformOrigin="0, 0.5" MinHeight="254">
+                                    <Grid x:Name="PART_MonthView" RenderTransformOrigin="0, 0.5">
                                         <Grid.RenderTransform>
                                             <TranslateTransform X="0" />
                                         </Grid.RenderTransform>


### PR DESCRIPTION
Fixes #15.

There's a lack of material-styled datepickers on the web that allow disabling dates, but [angular-md](https://material.angularjs.org/latest/demo/datepicker) is one.  Materialize CSS doesn't support disabled dates (yet), though its underlying implementation (`datepicker.js`) does.  Material Design Lite doesn't support a calendar at all.

The angular-md datepicker sets the opacity of the blackout dates to a low (35%-ish) value.

This seems to be the most standard and "material" way of doing things - variations on the base commit in this PR (`9d4147b`) tried a strike-through approach, but this never felt very material to me, especially when a large number of dates were blacked-out.

So, this PR takes the approach of lowering the opacity to indicate disabled/blacked-out dates.

This didn't look nice with the out-of-month dates also having their opacity lowered, so I hid the out-of-month dates from the user.  This feels right: I think having the opacity lowered like that, while Windows-standard, gives the sense that the items are disabled in a material-context, since the official documentation seems pretty rigid regarding which situations get a lower opacity.  [It's also what's done in the spec](https://www.google.com/design/spec/components/pickers.html).

Note that MSFT's implementation of `CalendarItem` explicitly sets `Visibility.Visible` on the `CalendarDayButton` when adding them to the grid, so we set the height to 0 for "inactive" dates.  As a result, not all months appear to have six rows of days (some 4, some 5, some 6).  That means we're saving some vertical space, with the added side effect that scrolling through these months causes the height of calendars styled with these items to vary.  This seems OK - that behavior can be observed in other calendars on the web that take this approach.