### PR TITLE
Fix buttons inside a PopupBox

### DIFF
--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -169,6 +169,7 @@
                                 <ListBoxItem>Hello World</ListBoxItem>
                                 <ListBoxItem>Nice Popup</ListBoxItem>
                                 <ListBoxItem>Goodbye.</ListBoxItem>
+                                <ListBoxItem><Button x:Name="PopupButton" Content="Button" Click="PopupButton_OnClick"/></ListBoxItem>
                             </ListBox>
                         </materialDesign:PopupBox>
                         <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="22">Material Design In XAML Toolkit</TextBlock>

--- a/MainDemo.Wpf/MainWindow.xaml.cs
+++ b/MainDemo.Wpf/MainWindow.xaml.cs
@@ -17,5 +17,10 @@ namespace MaterialDesignColors.WpfExample
         {
             MenuToggleButton.IsChecked = false;
         }
+
+        private void PopupButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            MessageBox.Show("PopupButton Clicked");
+        }
     } 
 }

--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -106,7 +106,7 @@ namespace MaterialDesignThemes.Wpf
         {
             var locationFromScreen = this.PlacementTarget.PointToScreen(new Point(0, 0));
 
-            var mainVisual = PlacementTarget.GetVisualAncestory().OfType<System.Windows.Media.Visual>().LastOrDefault();
+            var mainVisual = PlacementTarget.GetVisualAncestry().OfType<System.Windows.Media.Visual>().LastOrDefault();
             if (mainVisual == null) return new CustomPopupPlacement[0];
 
             var screenWidth = (int) DpiHelper.TransformToDeviceX(mainVisual, SystemParameters.PrimaryScreenWidth);

--- a/MaterialDesignThemes.Wpf/Extensions.cs
+++ b/MaterialDesignThemes.Wpf/Extensions.cs
@@ -41,6 +41,28 @@ namespace MaterialDesignThemes.Wpf
                 yield return leaf;
                 leaf = VisualTreeHelper.GetParent(leaf);
             }
-        } 
+        }
+
+        public static IEnumerable<DependencyObject> GetLogicalAncestory(this DependencyObject leaf)
+        {
+            while (leaf != null)
+            {
+                yield return leaf;
+                leaf = LogicalTreeHelper.GetParent(leaf);
+            }
+        }
+
+        public static bool HasAncestor(this DependencyObject leaf, DependencyObject ancestor)
+        {
+            var visualAncestry = leaf.GetVisualAncestory().ToArray();
+            if (visualAncestry.Contains(ancestor))
+            {
+                return true;
+            }
+
+            var lastVisualAncestor = visualAncestry.LastOrDefault();
+            var logicalAncestry = GetLogicalAncestory(lastVisualAncestor);
+            return logicalAncestry.Contains(ancestor);
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Extensions.cs
+++ b/MaterialDesignThemes.Wpf/Extensions.cs
@@ -24,17 +24,17 @@ namespace MaterialDesignThemes.Wpf
             }
         }
 
-        public static bool IsDescendant(this DependencyObject parent, DependencyObject node)
+        public static bool IsAncestorOf(this DependencyObject parent, DependencyObject node)
         {
             return node != null && parent.VisualDepthFirstTraversal().Contains(node);
         }
 
         /// <summary>
-        /// Returns full visual ancestory, starting at the leaf.
+        /// Returns full visual ancestry, starting at the leaf.
         /// </summary>
         /// <param name="leaf"></param>
         /// <returns></returns>
-        public static IEnumerable<DependencyObject> GetVisualAncestory(this DependencyObject leaf)
+        public static IEnumerable<DependencyObject> GetVisualAncestry(this DependencyObject leaf)
         {
             while (leaf != null)
             {
@@ -43,7 +43,7 @@ namespace MaterialDesignThemes.Wpf
             }
         }
 
-        public static IEnumerable<DependencyObject> GetLogicalAncestory(this DependencyObject leaf)
+        public static IEnumerable<DependencyObject> GetLogicalAncestry(this DependencyObject leaf)
         {
             while (leaf != null)
             {
@@ -52,17 +52,18 @@ namespace MaterialDesignThemes.Wpf
             }
         }
 
-        public static bool HasAncestor(this DependencyObject leaf, DependencyObject ancestor)
+        public static bool IsDescendantOf(this DependencyObject leaf, DependencyObject ancestor)
         {
-            var visualAncestry = leaf.GetVisualAncestory().ToArray();
-            if (visualAncestry.Contains(ancestor))
+            DependencyObject parent = null;
+            foreach (var node in leaf.GetVisualAncestry())
             {
-                return true;
+                if (Equals(node, ancestor))
+                    return true;
+
+                parent = node;
             }
 
-            var lastVisualAncestor = visualAncestry.LastOrDefault();
-            var logicalAncestry = GetLogicalAncestory(lastVisualAncestor);
-            return logicalAncestry.Contains(ancestor);
+            return parent != null && parent.GetLogicalAncestry().Contains(ancestor);
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -578,14 +578,14 @@ namespace MaterialDesignThemes.Wpf
             {
                 if (e.OriginalSource == popupBox)
                 {
-                    if (Mouse.Captured == null || popupBox._popup == null || !(Mouse.Captured as DependencyObject).HasAncestor(popupBox._popup))
+                    if (Mouse.Captured == null || popupBox._popup == null || !(Mouse.Captured as DependencyObject).IsDescendantOf(popupBox._popup))
                     {
                         popupBox.Close();
                     }
                 }
                 else
                 {
-                    if ((Mouse.Captured as DependencyObject).GetVisualAncestory().Contains(popupBox._popup))
+                    if ((Mouse.Captured as DependencyObject).GetVisualAncestry().Contains(popupBox._popup))
                     {
                         // Take capture if one of our children gave up capture (by closing their drop down)
                         if (popupBox.IsPopupOpen && Mouse.Captured == null && GetCapture() == IntPtr.Zero)

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -578,7 +578,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 if (e.OriginalSource == popupBox)
                 {
-                    if (Mouse.Captured == null || popupBox._popup == null || !(Mouse.Captured as DependencyObject).GetVisualAncestory().Contains(popupBox._popup))
+                    if (Mouse.Captured == null || popupBox._popup == null || !(Mouse.Captured as DependencyObject).HasAncestor(popupBox._popup))
                     {
                         popupBox.Close();
                     }


### PR DESCRIPTION
This fixes an issue clicking buttons inside of a PopupBox. The popup is dismissed before any action associated with the button can execute. 

The issue occurs because the content inside a Popup exists in a different visual tree from the Popup, so the button is not considered a visual descendant of the Popup. When the mouse capture is lost to the button, the popup is closed.

The issue is fixed by examining the logical ancestors of the popup content, which includes the Popup. The button click is then properly executed and the popup is closed.
