### PR TITLE
Hyperlink style

### DIFF
--- a/MainDemo.Wpf/Typography.xaml
+++ b/MainDemo.Wpf/Typography.xaml
@@ -1,69 +1,81 @@
 ﻿<UserControl x:Class="MaterialDesignColors.WpfExample.Typography"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             mc:Ignorable="d" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             mc:Ignorable="d"
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
         <Style TargetType="TextBlock" BasedOn="{StaticResource MaterialDesignCaptionTextBlock}">
             <Setter Property="Opacity" Value=".68"></Setter>
         </Style>
     </UserControl.Resources>
-    
-    <Grid Margin="32">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="64" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Row="0" Grid.Column="0" Margin="0 26 0 0">Display 4  - MaterialDesignDisplay4TextBlock</TextBlock>
-        <TextBlock Grid.Row="0" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay4TextBlock}" Margin="0 4 0 4">Light 112sp</TextBlock>
+    <ScrollViewer HorizontalScrollBarVisibility="Auto"
+                  VerticalScrollBarVisibility="Disabled">
+        <Grid Margin="32">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="64" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="64" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0" Grid.Column="0" Margin="0 26 0 0">Display 4  - MaterialDesignDisplay4TextBlock</TextBlock>
+            <TextBlock Grid.Row="0" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay4TextBlock}" Margin="0 4 0 4">Light 112sp</TextBlock>
+            <TextBlock Grid.Row="0" Grid.Column="4" Margin="0 4 0 4"><Hyperlink IsEnabled="False" Style="{StaticResource MaterialDesignDisplay4Hyperlink}">Light 112sp (Disabled)</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="1" Grid.Column="0" Margin="0 12 0 0">Display 3 - MaterialDesignDisplay3TextBlock</TextBlock>
-        <TextBlock Grid.Row="1" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay3TextBlock}" Margin="0 4 0 4">Regular 56sp</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="0" Margin="0 12 0 0">Display 3 - MaterialDesignDisplay3TextBlock</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay3TextBlock}" Margin="0 4 0 4">Regular 56sp</TextBlock>
+            <TextBlock Grid.Row="1" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignDisplay3Hyperlink}">Regular 56sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="2" Grid.Column="0" Margin="0 8 0 0">Display 2 - MaterialDesignDisplay2TextBlock</TextBlock>
-        <TextBlock Grid.Row="2" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay2TextBlock}" Margin="0 4 0 4">Regular 45sp</TextBlock>
+            <TextBlock Grid.Row="2" Grid.Column="0" Margin="0 8 0 0">Display 2 - MaterialDesignDisplay2TextBlock</TextBlock>
+            <TextBlock Grid.Row="2" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay2TextBlock}" Margin="0 4 0 4">Regular 45sp</TextBlock>
+            <TextBlock Grid.Row="2" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignDisplay2Hyperlink}">Regular 45sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="3" Grid.Column="0" Margin="0 8 0 0">Display 1 - MaterialDesignDisplay1TextBlock</TextBlock>
-        <TextBlock Grid.Row="3" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay1TextBlock}" Margin="0 4 0 4">Regular 34sp</TextBlock>
+            <TextBlock Grid.Row="3" Grid.Column="0" Margin="0 8 0 0">Display 1 - MaterialDesignDisplay1TextBlock</TextBlock>
+            <TextBlock Grid.Row="3" Grid.Column="2" Style="{StaticResource MaterialDesignDisplay1TextBlock}" Margin="0 4 0 4">Regular 34sp</TextBlock>
+            <TextBlock Grid.Row="3" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignDisplay1Hyperlink}">Regular 34sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="4" Grid.Column="0" Margin="0 8 0 0">Headline - MaterialDesignHeadlineTextBlock</TextBlock>
-        <TextBlock Grid.Row="4" Grid.Column="2" Style="{StaticResource MaterialDesignHeadlineTextBlock}" Margin="0 4 0 6">Regular 24sp</TextBlock>
+            <TextBlock Grid.Row="4" Grid.Column="0" Margin="0 8 0 0">Headline - MaterialDesignHeadlineTextBlock</TextBlock>
+            <TextBlock Grid.Row="4" Grid.Column="2" Style="{StaticResource MaterialDesignHeadlineTextBlock}" Margin="0 4 0 6">Regular 24sp</TextBlock>
+            <TextBlock Grid.Row="4" Grid.Column="4" Margin="0 4 0 4"><Hyperlink IsEnabled="False" Style="{StaticResource MaterialDesignHeadlineHyperlink}">Regular 24sp (Disabled)</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="5" Grid.Column="0" Margin="0 8 0 0">Title - MaterialDesignTitleTextBlock</TextBlock>
-        <TextBlock Grid.Row="5" Grid.Column="2" Style="{StaticResource MaterialDesignTitleTextBlock}" Margin="0 6 0 8">Medium 20sp</TextBlock>
+            <TextBlock Grid.Row="5" Grid.Column="0" Margin="0 8 0 0">Title - MaterialDesignTitleTextBlock</TextBlock>
+            <TextBlock Grid.Row="5" Grid.Column="2" Style="{StaticResource MaterialDesignTitleTextBlock}" Margin="0 6 0 8">Medium 20sp</TextBlock>
+            <TextBlock Grid.Row="5" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignTitleHyperlink}">Medium 20sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center">Subheading - MaterialDesignSubheadingTextBlock</TextBlock>
-        <TextBlock Grid.Row="6" Grid.Column="2" Style="{StaticResource MaterialDesignSubheadingTextBlock}" Margin="0 8 0 8">Regular 15sp</TextBlock>
+            <TextBlock Grid.Row="6" Grid.Column="0" VerticalAlignment="Center">Subheading - MaterialDesignSubheadingTextBlock</TextBlock>
+            <TextBlock Grid.Row="6" Grid.Column="2" Style="{StaticResource MaterialDesignSubheadingTextBlock}" Margin="0 8 0 8">Regular 15sp</TextBlock>
+            <TextBlock Grid.Row="6" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignSubheadingHyperlink}">Regular 15sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center">Body 2 - MaterialDesignBody2TextBlock</TextBlock>
-        <TextBlock Grid.Row="7" Grid.Column="2" Style="{StaticResource MaterialDesignBody2TextBlock}" Margin="0 8 0 8">Medium 13sp</TextBlock>
+            <TextBlock Grid.Row="7" Grid.Column="0" VerticalAlignment="Center">Body 2 - MaterialDesignBody2TextBlock</TextBlock>
+            <TextBlock Grid.Row="7" Grid.Column="2" Style="{StaticResource MaterialDesignBody2TextBlock}" Margin="0 8 0 8">Medium 13sp</TextBlock>
+            <TextBlock Grid.Row="7" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignBody2Hyperlink}">Medium 13sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center">Body 1 - MaterialDesignBody1TextBlock</TextBlock>
-        <TextBlock Grid.Row="8" Grid.Column="2" Style="{StaticResource MaterialDesignBody1TextBlock}" Margin="0 8 0 8">Regular 13sp</TextBlock>
+            <TextBlock Grid.Row="8" Grid.Column="0" VerticalAlignment="Center">Body 1 - MaterialDesignBody1TextBlock</TextBlock>
+            <TextBlock Grid.Row="8" Grid.Column="2" Style="{StaticResource MaterialDesignBody1TextBlock}" Margin="0 8 0 8">Regular 13sp</TextBlock>
+            <TextBlock Grid.Row="8" Grid.Column="4" Margin="0 4 0 4"><Hyperlink IsEnabled="False" Style="{StaticResource MaterialDesignBody1Hyperlink}">Regular 13sp (Disabled)</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="9" Grid.Column="0" VerticalAlignment="Center">Caption - MaterialDesignCaptionTextBlock</TextBlock>
-        <TextBlock Grid.Row="9" Grid.Column="2" Style="{StaticResource MaterialDesignCaptionTextBlock}" Margin="0 8 0 8">Regular 12sp</TextBlock>
+            <TextBlock Grid.Row="9" Grid.Column="0" VerticalAlignment="Center">Caption - MaterialDesignCaptionTextBlock</TextBlock>
+            <TextBlock Grid.Row="9" Grid.Column="2" Style="{StaticResource MaterialDesignCaptionTextBlock}" Margin="0 8 0 8">Regular 12sp</TextBlock>
+            <TextBlock Grid.Row="9" Grid.Column="4" Margin="0 4 0 4"><Hyperlink Style="{StaticResource MaterialDesignCaptionHyperlink}">Regular 12sp</Hyperlink></TextBlock>
 
-        <TextBlock Grid.Row="10" Grid.Column="0" VerticalAlignment="Center">Button - MaterialDesignButtonTextBlock</TextBlock>
-        <TextBlock Grid.Row="10" Grid.Column="2" Style="{StaticResource MaterialDesignButtonTextBlock}" Margin="0 8 0 8">MEDIUM (ALL CAPS) 14sp</TextBlock>
+            <TextBlock Grid.Row="10" Grid.Column="0" VerticalAlignment="Center">Button - MaterialDesignButtonTextBlock</TextBlock>
+            <TextBlock Grid.Row="10" Grid.Column="2" Style="{StaticResource MaterialDesignButtonTextBlock}" Margin="0 8 0 8">MEDIUM (ALL CAPS) 14sp</TextBlock>
 
-
-
-    </Grid>
+        </Grid>
+    </ScrollViewer>
 </UserControl>

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -140,6 +140,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Themes\MaterialDesignTheme.Hyperlink.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Themes\MaterialDesignTheme.TextBox.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -1,7 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf">
-    
+
     <!-- use this resource dictionary to set up the most common themese for standard controls -->
 
     <ResourceDictionary.MergedDictionaries>
@@ -14,6 +14,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Expander.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Font.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.GridSplitter.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Hyperlink.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.Label.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.Listbox.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
@@ -38,11 +39,11 @@
     <Style TargetType="{x:Type CheckBox}" BasedOn="{StaticResource MaterialDesignCheckBox}" />
     <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignComboBox}" />
     <Style TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource MaterialDesignContextMenu}" />
-    <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource MaterialDesignDataGrid}" />    
-    <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource MaterialDesignDataGridCell}" />    
-    <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}" />    
-    <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MaterialDesignDataGridRow}" />    
-    <Style TargetType="{x:Type DataGridRowHeader}" BasedOn="{StaticResource MaterialDesignDataGridRowHeader}" />        
+    <Style TargetType="{x:Type DataGrid}" BasedOn="{StaticResource MaterialDesignDataGrid}" />
+    <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource MaterialDesignDataGridCell}" />
+    <Style TargetType="{x:Type DataGridColumnHeader}" BasedOn="{StaticResource MaterialDesignDataGridColumnHeader}" />
+    <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource MaterialDesignDataGridRow}" />
+    <Style TargetType="{x:Type DataGridRowHeader}" BasedOn="{StaticResource MaterialDesignDataGridRowHeader}" />
     <Style TargetType="{x:Type DatePicker}" BasedOn="{StaticResource MaterialDesignDatePicker}" />
     <Style TargetType="{x:Type Expander}" BasedOn="{StaticResource MaterialDesignExpander}" />
     <Style TargetType="{x:Type GridSplitter}" BasedOn="{StaticResource MaterialDesignGridSplitter}" />
@@ -50,11 +51,11 @@
     <Style TargetType="{x:Type ListBox}" BasedOn="{StaticResource MaterialDesignListBox}" />
     <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignPasswordBox}" />
     <Style TargetType="{x:Type ProgressBar}" BasedOn="{StaticResource MaterialDesignLinearProgressBar}" />
-    <Style TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}" />    
+    <Style TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}" />
     <Style TargetType="{x:Type ScrollBar}" BasedOn="{StaticResource MaterialDesignScrollBar}" />
     <Style TargetType="{x:Type ScrollViewer}" BasedOn="{StaticResource MaterialDesignScrollViewer}" />
     <Style TargetType="{x:Type Slider}" BasedOn="{StaticResource MaterialDesignSlider}" />
-    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />    
+    <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}" />
     <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignSwitchToggleButton}" />
     <Style TargetType="{x:Type ToolBar}" BasedOn="{StaticResource MaterialDesignToolBar}" />
     <Style TargetType="{x:Type ToolBarTray}" BasedOn="{StaticResource MaterialDesignToolBarTray}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
@@ -11,7 +11,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -29,7 +29,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -47,7 +47,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -65,7 +65,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -83,7 +83,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -101,7 +101,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -119,7 +119,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -137,7 +137,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -155,7 +155,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />
@@ -173,7 +173,7 @@
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
-                    Value="{DynamicResource PrimaryHueLightBrush}" />
+                    Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="true">
                 <Setter Property="Cursor" Value="Hand" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
@@ -4,6 +4,7 @@
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -21,6 +22,7 @@
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -38,6 +40,7 @@
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -55,6 +58,7 @@
         <Setter Property="FontSize" Value="15"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -72,6 +76,7 @@
         <Setter Property="FontSize" Value="20"/>
         <Setter Property="FontWeight" Value="Medium"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -89,6 +94,7 @@
         <Setter Property="FontSize" Value="24"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -106,6 +112,7 @@
         <Setter Property="FontSize" Value="34"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -123,6 +130,7 @@
         <Setter Property="FontSize" Value="45"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -140,6 +148,7 @@
         <Setter Property="FontSize" Value="56"/>
         <Setter Property="FontWeight" Value="Regular"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -157,6 +166,7 @@
         <Setter Property="FontSize" Value="112"/>
         <Setter Property="FontWeight" Value="Light"/>
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Setter Property="TextDecorations" Value="None" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
                 <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
@@ -1,0 +1,173 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignCaptionHyperlink">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignBody1Hyperlink">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignBody2Hyperlink">
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="FontWeight" Value="Medium"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignSubheadingHyperlink">
+        <Setter Property="FontSize" Value="15"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignTitleHyperlink">
+        <Setter Property="FontSize" Value="20"/>
+        <Setter Property="FontWeight" Value="Medium"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignHeadlineHyperlink">
+        <Setter Property="FontSize" Value="24"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignDisplay1Hyperlink">
+        <Setter Property="FontSize" Value="34"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignDisplay2Hyperlink">
+        <Setter Property="FontSize" Value="45"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignDisplay3Hyperlink">
+        <Setter Property="FontSize" Value="56"/>
+        <Setter Property="FontWeight" Value="Regular"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    <Style TargetType="{x:Type Hyperlink}" x:Key="MaterialDesignDisplay4Hyperlink">
+        <Setter Property="FontSize" Value="112"/>
+        <Setter Property="FontWeight" Value="Light"/>
+        <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="false">
+                <Setter Property="Foreground"
+                    Value="{DynamicResource PrimaryHueLightBrush}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="true">
+                <Setter Property="Cursor" Value="Hand" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+</ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Hyperlink.xaml
@@ -6,7 +6,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -23,7 +23,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -40,7 +40,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -57,7 +57,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -74,7 +74,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -91,7 +91,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -108,7 +108,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -125,7 +125,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -142,7 +142,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"
@@ -159,7 +159,7 @@
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}" />
         <Style.Triggers>
             <Trigger Property="IsMouseOver" Value="true">
-                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueLightBrush}" />
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
             </Trigger>
             <Trigger Property="IsEnabled" Value="false">
                 <Setter Property="Foreground"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBlock.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBlock.xaml
@@ -1,47 +1,80 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Hyperlink.xaml" />
+    </ResourceDictionary.MergedDictionaries>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignCaptionTextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignCaptionHyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="12"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignBody1TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignBody1Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignBody2TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignBody2Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="13"/>
         <Setter Property="FontWeight" Value="Medium"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignSubheadingTextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignSubheadingHyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="15"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignTitleTextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignTitleHyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="20"/>
         <Setter Property="FontWeight" Value="Medium"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignHeadlineTextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignHeadlineHyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="24"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignDisplay1TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignDisplay1Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="34"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignDisplay2TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignDisplay2Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="45"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignDisplay3TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignDisplay3Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="56"/>
         <Setter Property="FontWeight" Value="Regular"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignDisplay4TextBlock">
+        <Style.Resources>
+            <Style TargetType="Hyperlink" BasedOn="{StaticResource MaterialDesignDisplay4Hyperlink}" />
+        </Style.Resources>
         <Setter Property="FontSize" Value="112"/>
         <Setter Property="FontWeight" Value="Light"/>
     </Style>
     <Style TargetType="{x:Type TextBlock}" x:Key="MaterialDesignButtonTextBlock">
         <Setter Property="FontSize" Value="14"/>
         <Setter Property="FontWeight" Value="Medium"/>
-    </Style>    
+    </Style>
 </ResourceDictionary>


### PR DESCRIPTION
I just added styles for the hyperlink control.
They are size and font weight matching with the Textblock styles so that it is easy to use them beside text. Foreground and hover color are based on the current accent (PrimaryHue dark and light).

Using the accent should mirror the style descibed on this page: [Google material design](https://www.google.com/design/spec/style/color.html#color-ui-color-application) under the paragraph accent color.

I also added them to the typography page of the demo application.

This is my first contribution on git-hub i hope that i have not done anything wrong.