### PR TITLE
Fix for MaterialDesignFlatToggleButton

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -177,94 +177,98 @@
 		<Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
 	</Style>
 
-    <Style x:Key="MaterialDesignFlatToggleButton" TargetType="{x:Type ToggleButton}">
-		<Setter Property="Foreground" Value="#616161"/>
-		<Setter Property="Background" Value="#e0e0e0"/>
-		<Setter Property="Width" Value="40"/>
-		<Setter Property="Height" Value="40"/>
-		<Setter Property="FontSize" Value="18"/>
-		<Setter Property="HorizontalContentAlignment" Value="Center"/>
-		<Setter Property="VerticalContentAlignment" Value="Center"/>
-		<Setter Property="Padding" Value="0"/>
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="{x:Type ToggleButton}">
-					<Grid Clip="{Binding ElementName=UncheckedEllipse, Path=RenderedGeometry}" ClipToBounds="True">
-						<VisualStateManager.VisualStateGroups>
-							<VisualStateGroup x:Name="CommonStates">
-								<VisualState x:Name="Normal"/>
-								<VisualState x:Name="Disabled">
-									<Storyboard>
-										<DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
-									</Storyboard>
-								</VisualState>                                
-							</VisualStateGroup>
-							<VisualStateGroup x:Name="CheckStates">
-                                <VisualStateGroup.Transitions>
-                                    <VisualTransition From="*" To="Checked">
-                                        <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="(Control.Width)" Storyboard.TargetName="CheckedEllipse">
-                                                <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-                                                <LinearDoubleKeyFrame Value="40" KeyTime="0:0:0.1" />
-                                            </DoubleAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="(Control.Height)" Storyboard.TargetName="CheckedEllipse">
-                                                <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-                                                <LinearDoubleKeyFrame Value="40" KeyTime="0:0:0.1" />
-                                            </DoubleAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualTransition>
-                                    <VisualTransition From="Checked" To="Unchecked">
-                                        <Storyboard>
-                                            <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="(Control.Width)" Storyboard.TargetName="CheckedEllipse">
-                                                <LinearDoubleKeyFrame Value="40" KeyTime="0:0:0.0" />
-                                                <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-                                            </DoubleAnimationUsingKeyFrames>
-                                            <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="(Control.Height)" Storyboard.TargetName="CheckedEllipse">
-                                                <LinearDoubleKeyFrame Value="40" KeyTime="0:0:0.0" />
-                                                <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-                                            </DoubleAnimationUsingKeyFrames>
-                                        </Storyboard>
-                                    </VisualTransition>
-                                </VisualStateGroup.Transitions>
-								<VisualState x:Name="Checked">
-									<Storyboard>
-                                        <DoubleAnimation Duration="0" Storyboard.TargetProperty="(Control.Width)" Storyboard.TargetName="CheckedEllipse"
-                                                         To="40" />
-                                        <DoubleAnimation Duration="0" Storyboard.TargetProperty="(Control.Height)" Storyboard.TargetName="CheckedEllipse"
-                                                         To="40" />
-									</Storyboard>
-								</VisualState>
-								<VisualState x:Name="Unchecked">
-									<Storyboard>
-										<DoubleAnimation Duration="0" Storyboard.TargetProperty="(Control.Width)" Storyboard.TargetName="CheckedEllipse"
+  <Style x:Key="MaterialDesignFlatToggleButton" TargetType="{x:Type ToggleButton}">
+    <Setter Property="Foreground" Value="#616161"/>
+    <Setter Property="Background" Value="#e0e0e0"/>
+    <Setter Property="Width" Value="40"/>
+    <Setter Property="Height" Value="40"/>
+    <Setter Property="FontSize" Value="18"/>
+    <Setter Property="HorizontalContentAlignment" Value="Center"/>
+    <Setter Property="VerticalContentAlignment" Value="Center"/>
+    <Setter Property="Padding" Value="0"/>
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type ToggleButton}">
+          <Grid ClipToBounds="True" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
+            <VisualStateManager.VisualStateGroups>
+              <VisualStateGroup x:Name="CommonStates">
+                <VisualState x:Name="Normal"/>
+                <VisualState x:Name="Disabled">
+                  <Storyboard>
+                    <DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+              <VisualStateGroup x:Name="CheckStates">
+                <VisualStateGroup.Transitions>
+                  <VisualTransition From="*" To="Checked">
+                    <Storyboard>
+                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+                      </DoubleAnimationUsingKeyFrames>
+                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+                      </DoubleAnimationUsingKeyFrames>
+                    </Storyboard>
+                  </VisualTransition>
+                  <VisualTransition From="Checked" To="Unchecked">
+                    <Storyboard>
+                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+                      </DoubleAnimationUsingKeyFrames>
+                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+                      </DoubleAnimationUsingKeyFrames>
+                    </Storyboard>
+                  </VisualTransition>
+                </VisualStateGroup.Transitions>
+                <VisualState x:Name="Checked">
+                  <Storyboard>
+                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale"
+                                                         To="1.0" />
+                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale"
+                                                         To="1.0" />
+                  </Storyboard>
+                </VisualState>
+                <VisualState x:Name="Unchecked">
+                  <Storyboard>
+                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale"
                                                          To="0" />
-                                        <DoubleAnimation Duration="0" Storyboard.TargetProperty="(Control.Height)" Storyboard.TargetName="CheckedEllipse"
-                                                         To="0" />																				
-									</Storyboard>
-								</VisualState>
-							</VisualStateGroup>
-						</VisualStateManager.VisualStateGroups>
-                        <Ellipse Fill="Transparent" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" x:Name="HoverEllipse"
+                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale"
+                                                         To="0" />
+                  </Storyboard>
+                </VisualState>
+              </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <Ellipse Fill="Transparent" x:Name="HoverEllipse"
                                  Stroke="Transparent" StrokeThickness="1" />
-						<Ellipse Fill="{TemplateBinding Background}" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" x:Name="CheckedEllipse" />
-						<ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-					</Grid>
-					<ControlTemplate.Triggers>
-						<Trigger Property="IsMouseOver" Value="true">
-							<Setter Property="Stroke" TargetName="HoverEllipse" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />							
-						</Trigger>
-						<!-- TODO
+            <Ellipse Fill="{TemplateBinding Background}" x:Name="CheckedEllipse" RenderTransformOrigin="0.5, 0.5">
+              <Ellipse.RenderTransform>
+                <ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.0" ScaleY="1.0" x:Name="CheckedEllipseScale"/>
+              </Ellipse.RenderTransform>
+            </Ellipse>
+            <ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="true">
+              <Setter Property="Stroke" TargetName="HoverEllipse" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />
+            </Trigger>
+            <!-- TODO
 							<Trigger Property="IsFocused" Value="True">
 								<Setter Property="BorderBrush" TargetName="normal" Value="{Binding (Custom:ControlsHelper.FocusBorderBrush), RelativeSource={RelativeSource TemplatedParent}}"/>
 							</Trigger>
 							-->
-					</ControlTemplate.Triggers>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</Style>
-    
-    <Style x:Key="MaterialDesignFlatPrimaryToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignFlatToggleButton}">
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+  </Style>    
+  
+  <Style x:Key="MaterialDesignFlatPrimaryToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignFlatToggleButton}">
 		<Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}"/>		
 		<Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}"/>
 	</Style>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -190,62 +190,62 @@
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type ToggleButton}">
 					<Grid ClipToBounds="True" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
-					<VisualStateManager.VisualStateGroups>
-						<VisualStateGroup x:Name="CommonStates">
-							<VisualState x:Name="Normal"/>
-							<VisualState x:Name="Disabled">
-								<Storyboard>
-									<DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
-								</Storyboard>
-							</VisualState>
-						</VisualStateGroup>
-						<VisualStateGroup x:Name="CheckStates">
-							<VisualStateGroup.Transitions>
-								<VisualTransition From="*" To="Checked">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal"/>
+								<VisualState x:Name="Disabled">
 									<Storyboard>
-										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
-											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
-										</DoubleAnimationUsingKeyFrames>
-										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
-											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
-										</DoubleAnimationUsingKeyFrames>
+										<DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
 									</Storyboard>
-								</VisualTransition>
-								<VisualTransition From="Checked" To="Unchecked">
+								</VisualState>
+							</VisualStateGroup>
+							<VisualStateGroup x:Name="CheckStates">
+								<VisualStateGroup.Transitions>
+									<VisualTransition From="*" To="Checked">
+										<Storyboard>
+											<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+												<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+												<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+											</DoubleAnimationUsingKeyFrames>
+											<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+												<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+												<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+									<VisualTransition From="Checked" To="Unchecked">
+										<Storyboard>
+											<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+												<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+												<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+											</DoubleAnimationUsingKeyFrames>
+											<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+												<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+												<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+											</DoubleAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualTransition>
+								</VisualStateGroup.Transitions>
+								<VisualState x:Name="Checked">
 									<Storyboard>
-										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
-											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
-											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-										</DoubleAnimationUsingKeyFrames>
-										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
-											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
-											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-										</DoubleAnimationUsingKeyFrames>
+										<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
+										<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
 									</Storyboard>
-								</VisualTransition>
-							</VisualStateGroup.Transitions>
-							<VisualState x:Name="Checked">
-								<Storyboard>
-									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
-									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
-								</Storyboard>
-							</VisualState>
-							<VisualState x:Name="Unchecked">
-								<Storyboard>
-									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="0" />
-									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="0" />
-								</Storyboard>
-							</VisualState>
-						</VisualStateGroup>
-					</VisualStateManager.VisualStateGroups>
-					<Ellipse Fill="Transparent" x:Name="HoverEllipse" Stroke="Transparent" StrokeThickness="1" />
-					<Ellipse Fill="{TemplateBinding Background}" x:Name="CheckedEllipse" RenderTransformOrigin="0.5, 0.5">
-						<Ellipse.RenderTransform>
-							<ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.0" ScaleY="1.0" x:Name="CheckedEllipseScale"/>
-						</Ellipse.RenderTransform>
-					</Ellipse>
+								</VisualState>
+								<VisualState x:Name="Unchecked">
+									<Storyboard>
+										<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="0" />
+										<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="0" />
+									</Storyboard>
+								</VisualState>
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<Ellipse Fill="Transparent" x:Name="HoverEllipse" Stroke="Transparent" StrokeThickness="1" />
+						<Ellipse Fill="{TemplateBinding Background}" x:Name="CheckedEllipse" RenderTransformOrigin="0.5, 0.5">
+							<Ellipse.RenderTransform>
+								<ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.0" ScaleY="1.0" x:Name="CheckedEllipseScale"/>
+							</Ellipse.RenderTransform>
+						</Ellipse>
 						<ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
 					</Grid>
 					<ControlTemplate.Triggers>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -177,98 +177,93 @@
 		<Setter Property="Foreground" Value="{DynamicResource SecondaryAccentForegroundBrush}"/>
 	</Style>
 
-  <Style x:Key="MaterialDesignFlatToggleButton" TargetType="{x:Type ToggleButton}">
-    <Setter Property="Foreground" Value="#616161"/>
-    <Setter Property="Background" Value="#e0e0e0"/>
-    <Setter Property="Width" Value="40"/>
-    <Setter Property="Height" Value="40"/>
-    <Setter Property="FontSize" Value="18"/>
-    <Setter Property="HorizontalContentAlignment" Value="Center"/>
-    <Setter Property="VerticalContentAlignment" Value="Center"/>
-    <Setter Property="Padding" Value="0"/>
-    <Setter Property="Template">
-      <Setter.Value>
-        <ControlTemplate TargetType="{x:Type ToggleButton}">
-          <Grid ClipToBounds="True" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
-            <VisualStateManager.VisualStateGroups>
-              <VisualStateGroup x:Name="CommonStates">
-                <VisualState x:Name="Normal"/>
-                <VisualState x:Name="Disabled">
-                  <Storyboard>
-                    <DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
-                  </Storyboard>
-                </VisualState>
-              </VisualStateGroup>
-              <VisualStateGroup x:Name="CheckStates">
-                <VisualStateGroup.Transitions>
-                  <VisualTransition From="*" To="Checked">
-                    <Storyboard>
-                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
-                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
-                      </DoubleAnimationUsingKeyFrames>
-                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
-                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
-                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
-                      </DoubleAnimationUsingKeyFrames>
-                    </Storyboard>
-                  </VisualTransition>
-                  <VisualTransition From="Checked" To="Unchecked">
-                    <Storyboard>
-                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
-                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
-                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-                      </DoubleAnimationUsingKeyFrames>
-                      <DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
-                        <LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
-                        <LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
-                      </DoubleAnimationUsingKeyFrames>
-                    </Storyboard>
-                  </VisualTransition>
-                </VisualStateGroup.Transitions>
-                <VisualState x:Name="Checked">
-                  <Storyboard>
-                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale"
-                                                         To="1.0" />
-                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale"
-                                                         To="1.0" />
-                  </Storyboard>
-                </VisualState>
-                <VisualState x:Name="Unchecked">
-                  <Storyboard>
-                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale"
-                                                         To="0" />
-                    <DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale"
-                                                         To="0" />
-                  </Storyboard>
-                </VisualState>
-              </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
-            <Ellipse Fill="Transparent" x:Name="HoverEllipse"
-                                 Stroke="Transparent" StrokeThickness="1" />
-            <Ellipse Fill="{TemplateBinding Background}" x:Name="CheckedEllipse" RenderTransformOrigin="0.5, 0.5">
-              <Ellipse.RenderTransform>
-                <ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.0" ScaleY="1.0" x:Name="CheckedEllipseScale"/>
-              </Ellipse.RenderTransform>
-            </Ellipse>
-            <ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-          </Grid>
-          <ControlTemplate.Triggers>
-            <Trigger Property="IsMouseOver" Value="true">
-              <Setter Property="Stroke" TargetName="HoverEllipse" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />
-            </Trigger>
-            <!-- TODO
-							<Trigger Property="IsFocused" Value="True">
-								<Setter Property="BorderBrush" TargetName="normal" Value="{Binding (Custom:ControlsHelper.FocusBorderBrush), RelativeSource={RelativeSource TemplatedParent}}"/>
-							</Trigger>
-							-->
-          </ControlTemplate.Triggers>
-        </ControlTemplate>
-      </Setter.Value>
-    </Setter>
-  </Style>    
+	<Style x:Key="MaterialDesignFlatToggleButton" TargetType="{x:Type ToggleButton}">
+		<Setter Property="Foreground" Value="#616161"/>
+		<Setter Property="Background" Value="#e0e0e0"/>
+		<Setter Property="Width" Value="40"/>
+		<Setter Property="Height" Value="40"/>
+		<Setter Property="FontSize" Value="18"/>
+		<Setter Property="HorizontalContentAlignment" Value="Center"/>
+		<Setter Property="VerticalContentAlignment" Value="Center"/>
+		<Setter Property="Padding" Value="0"/>
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="{x:Type ToggleButton}">
+					<Grid ClipToBounds="True" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}">
+					<VisualStateManager.VisualStateGroups>
+						<VisualStateGroup x:Name="CommonStates">
+							<VisualState x:Name="Normal"/>
+							<VisualState x:Name="Disabled">
+								<Storyboard>
+									<DoubleAnimation Duration="0" To="0.23" Storyboard.TargetProperty="(UIElement.Opacity)" />
+								</Storyboard>
+							</VisualState>
+						</VisualStateGroup>
+						<VisualStateGroup x:Name="CheckStates">
+							<VisualStateGroup.Transitions>
+								<VisualTransition From="*" To="Checked">
+									<Storyboard>
+										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+										</DoubleAnimationUsingKeyFrames>
+										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.0" />
+											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.1" />
+										</DoubleAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualTransition>
+								<VisualTransition From="Checked" To="Unchecked">
+									<Storyboard>
+										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale">
+											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+										</DoubleAnimationUsingKeyFrames>
+										<DoubleAnimationUsingKeyFrames Duration="0:0:0.2" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale">
+											<LinearDoubleKeyFrame Value="1.0" KeyTime="0:0:0.0" />
+											<LinearDoubleKeyFrame Value="0" KeyTime="0:0:0.1" />
+										</DoubleAnimationUsingKeyFrames>
+									</Storyboard>
+								</VisualTransition>
+							</VisualStateGroup.Transitions>
+							<VisualState x:Name="Checked">
+								<Storyboard>
+									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
+									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="1.0" />
+								</Storyboard>
+							</VisualState>
+							<VisualState x:Name="Unchecked">
+								<Storyboard>
+									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="CheckedEllipseScale" To="0" />
+									<DoubleAnimation Duration="0" Storyboard.TargetProperty="ScaleY" Storyboard.TargetName="CheckedEllipseScale" To="0" />
+								</Storyboard>
+							</VisualState>
+						</VisualStateGroup>
+					</VisualStateManager.VisualStateGroups>
+					<Ellipse Fill="Transparent" x:Name="HoverEllipse" Stroke="Transparent" StrokeThickness="1" />
+					<Ellipse Fill="{TemplateBinding Background}" x:Name="CheckedEllipse" RenderTransformOrigin="0.5, 0.5">
+						<Ellipse.RenderTransform>
+							<ScaleTransform CenterX="0.5" CenterY="0.5" ScaleX="1.0" ScaleY="1.0" x:Name="CheckedEllipseScale"/>
+						</Ellipse.RenderTransform>
+					</Ellipse>
+						<ContentPresenter x:Name="contentPresenter" ContentTemplate="{TemplateBinding ContentTemplate}" Content="{TemplateBinding Content}" HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" Margin="{TemplateBinding Padding}" VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+					</Grid>
+					<ControlTemplate.Triggers>
+            					<Trigger Property="IsMouseOver" Value="true">
+              						<Setter Property="Stroke" TargetName="HoverEllipse" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Background}" />
+            					</Trigger>
+            					<!-- TODO
+						<Trigger Property="IsFocused" Value="True">
+							<Setter Property="BorderBrush" TargetName="normal" Value="{Binding (Custom:ControlsHelper.FocusBorderBrush), RelativeSource={RelativeSource TemplatedParent}}"/>
+						</Trigger>
+						-->
+          				</ControlTemplate.Triggers>
+        			</ControlTemplate>
+      			</Setter.Value>
+		</Setter>
+	</Style>    
   
-  <Style x:Key="MaterialDesignFlatPrimaryToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignFlatToggleButton}">
+	<Style x:Key="MaterialDesignFlatPrimaryToggleButton" TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource MaterialDesignFlatToggleButton}">
 		<Setter Property="Background" Value="{DynamicResource PrimaryHueLightBrush}"/>		
 		<Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}"/>
 	</Style>


### PR DESCRIPTION
This is a fix for MaterialDesignFlatToggleButton so it can adapt to any kind of size (even non rectangular ones) by using a render scale transform instead of fixed values.
The same could be considered for the action button.