### PR TITLE
RecognizesAccessKey for Ripple

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -144,15 +144,15 @@
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0 16 0 0">
             <Button Style="{StaticResource MaterialDesignRaisedLightButton}" Margin="0 0 8 0" Width="100"
                     ToolTip="Resource name: MaterialDesignRaisedLightButton">
-                LIGHT
+                _LIGHT
             </Button>
             <Button Style="{StaticResource MaterialDesignRaisedButton}" Margin="0 0 8 0" Width="100"
                     ToolTip="Resource name: MaterialDesignRaisedButton">
-                MID
+                _MID
             </Button>
             <Button Style="{StaticResource MaterialDesignRaisedDarkButton}" Margin="0 0 8 0" Width="100"
                     ToolTip="Resource name: MaterialDesignRaisedLightDarkButton">
-                DARK
+                _DARK
             </Button>
             <Button Style="{StaticResource MaterialDesignRaisedAccentButton}" Margin="0 0 8 0" Width="100"
                     ToolTip="Resource name: MaterialDesignRaisedAccentButton">

--- a/MaterialDesignThemes.Wpf/Ripple.cs
+++ b/MaterialDesignThemes.Wpf/Ripple.cs
@@ -140,7 +140,25 @@ namespace MaterialDesignThemes.Wpf
         {
             get { return (double)GetValue(RippleYProperty); }
             private set { SetValue(RippleYPropertyKey, value); }
-        }       
+        }
+
+        /// <summary>
+        ///   The DependencyProperty for the RecognizesAccessKey property. 
+        ///   Default Value: false 
+        /// </summary> 
+        public static readonly DependencyProperty RecognizesAccessKeyProperty =
+            DependencyProperty.Register(
+                "RecognizesAccessKey", typeof(bool), typeof(Ripple),
+                new PropertyMetadata(default(bool)));
+
+        /// <summary> 
+        ///   Determine if Ripple should use AccessText in its style
+        /// </summary> 
+        public bool RecognizesAccessKey
+        {
+            get { return (bool)GetValue(RecognizesAccessKeyProperty); }
+            set { SetValue(RecognizesAccessKeyProperty, value); }
+        }
 
         public override void OnApplyTemplate()
         {

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -32,6 +32,7 @@
     <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
     
     <Style TargetType="{x:Type local:Ripple}">
+        <Setter Property="RecognizesAccessKey" Value="True" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
@@ -133,11 +134,14 @@
                             </Ellipse>
                         </Canvas>
                         <ContentPresenter Content="{TemplateBinding Content}"
+                                          ContentStringFormat="{TemplateBinding ContentStringFormat}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"
                                           ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
                                           Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          RecognizesAccessKey="{TemplateBinding RecognizesAccessKey}"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
                     </Grid>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
It seems like this was lost by some other changes...

- new `RecognizesAccessKey` dependency property for `Ripple`
- default to `true`

![2016-01-12_15h15_16](https://cloud.githubusercontent.com/assets/658431/12265763/4f3894d6-b93f-11e5-881b-6acdfc5e4d14.png)

Closes #199 Controls don't support accessor keys 