### PR TITLE
Added cachemode to shadows for performance

### DIFF
--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Flyout.xaml
@@ -102,9 +102,7 @@
     <ControlTemplate x:Key="FlyoutTemplate"
                      TargetType="{x:Type Controls:Flyout}">
         <Grid x:Name="root"
-              Margin="{TemplateBinding Margin}"
-              Background="{TemplateBinding Background}"
-              Effect="{DynamicResource MaterialDesignShadowDepth5}">
+              Margin="{TemplateBinding Margin}">
             <Grid.RenderTransform>
                 <TranslateTransform />
             </Grid.RenderTransform>
@@ -212,6 +210,12 @@
                     </VisualState>
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
+            <AdornerDecorator>
+                <AdornerDecorator.CacheMode>
+                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                </AdornerDecorator.CacheMode>
+                <Border Background="{TemplateBinding Background}" Effect="{DynamicResource MaterialDesignShadowDepth5}"/>
+            </AdornerDecorator>
             <AdornerDecorator>
                 <DockPanel FocusVisualStyle="{x:Null}"
                            Focusable="False">

--- a/MaterialDesignThemes.Wpf/Converters/ShadowConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowConverter.cs
@@ -21,7 +21,7 @@ namespace MaterialDesignThemes.Wpf.Converters
 
             ShadowsDictionary = new Dictionary<ShadowDepth, DropShadowEffect>
             {
-                { ShadowDepth.Depth0, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth0"] },
+                { ShadowDepth.Depth0, null },
                 { ShadowDepth.Depth1, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth1"] },
                 { ShadowDepth.Depth2, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth2"] },
                 { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
@@ -44,6 +44,7 @@ namespace MaterialDesignThemes.Wpf.Converters
 
         private static DropShadowEffect Clone(DropShadowEffect dropShadowEffect)
         {
+            if (dropShadowEffect == null) return null;
             return new DropShadowEffect()
             {
                 BlurRadius = dropShadowEffect.BlurRadius,

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -29,7 +29,7 @@ namespace MaterialDesignThemes.Wpf
     public static class ShadowAssist
     {
         public static readonly DependencyProperty ShadowDepthProperty = DependencyProperty.RegisterAttached(
-            "ShadowDepth", typeof (ShadowDepth), typeof (ShadowAssist), new PropertyMetadata(default(ShadowDepth)));
+            "ShadowDepth", typeof (ShadowDepth), typeof (ShadowAssist), new FrameworkPropertyMetadata(default(ShadowDepth), FrameworkPropertyMetadataOptions.AffectsRender));
 
         public static void SetShadowDepth(DependencyObject element, ShadowDepth value)
         {
@@ -55,7 +55,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DarkenProperty = DependencyProperty.RegisterAttached(
-            "Darken", typeof (bool), typeof (ShadowAssist), new PropertyMetadata(default(bool), DarkenPropertyChangedCallback));
+            "Darken", typeof (bool), typeof (ShadowAssist), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.AffectsRender, DarkenPropertyChangedCallback));
 
         private static void DarkenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -381,9 +381,15 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:ColorZone}">
                     <Grid Background="Transparent">
-                        <Border Background="{TemplateBinding Background}"
-                                CornerRadius="{TemplateBinding CornerRadius}"
-                                Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                            </AdornerDecorator.CacheMode>
+                            <Border Background="{TemplateBinding Background}"
+                                    CornerRadius="{TemplateBinding CornerRadius}"                                
+                                    Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
+                            </Border>
+                        </AdornerDecorator>
                         <Border Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
@@ -733,10 +739,17 @@
                                 <TranslateTransform x:Name="LeftDrawerTranslateTransform"
                                                     X="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Grid}, Path=ActualWidth, Converter={StaticResource DrawerOffsetConverter}}" />
                             </Grid.RenderTransform>
-                            <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                    Opacity="0"
-                                    Background="{TemplateBinding LeftDrawerBackground}"
-                                    x:Name="LeftDrawerShadow" />
+                            <AdornerDecorator>
+                                <AdornerDecorator.CacheMode>
+                                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                </AdornerDecorator.CacheMode>
+                                <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                        Opacity="0"
+                                        Background="{TemplateBinding LeftDrawerBackground}"
+                                        x:Name="LeftDrawerShadow">
+                                </Border>
+                            </AdornerDecorator>
+
                             <ContentPresenter Content="{TemplateBinding LeftDrawerContent}" ContentTemplate="{TemplateBinding LeftDrawerContentTemplate}" ContentStringFormat="{TemplateBinding LeftDrawerContentStringFormat}" />
                         </Grid>
                     </Grid>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Button.xaml
@@ -61,9 +61,15 @@
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid>
-                        <Border Background="{TemplateBinding Background}" 
-                                x:Name="ShadowBorder"                                
-                                Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                            </AdornerDecorator.CacheMode>
+                            <Border Background="{TemplateBinding Background}" 
+                                    x:Name="ShadowBorder"                                
+                                    Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
+                            </Border>
+                        </AdornerDecorator>
                         <Border Background="{TemplateBinding Background}" x:Name="border" CornerRadius="2" />
                         <Border Background="White" CornerRadius="2" x:Name="ClickBorder" Opacity="0" RenderTransformOrigin="0.5,0.5" >
                             <Border.RenderTransform>
@@ -237,9 +243,15 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
                     <Grid>
-                        <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}" 
-                                 Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                 x:Name="border" />
+                        <AdornerDecorator>
+                            <AdornerDecorator.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                            </AdornerDecorator.CacheMode>
+                            <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}" 
+                                     Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                     x:Name="border">
+                            </Ellipse>
+                        </AdornerDecorator>
                         <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"  
                                     Feedback="White"
                                     Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}" ClipToBounds="True"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -11,12 +11,17 @@
 
     <ControlTemplate TargetType="{x:Type wpf:Card}" x:Key="CardTemplate">
         <Grid Margin="{TemplateBinding Margin}" Background="Transparent">
-            <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                    CornerRadius="{TemplateBinding UniformCornerRadius}">
-                <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
-                        x:Name="PART_ClipBorder"
-                        Clip="{TemplateBinding ContentClip}" />                        
-            </Border>
+            <AdornerDecorator>
+                <AdornerDecorator.CacheMode>
+                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                </AdornerDecorator.CacheMode>
+                <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                        CornerRadius="{TemplateBinding UniformCornerRadius}">
+                    <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
+                            x:Name="PART_ClipBorder"
+                            Clip="{TemplateBinding ContentClip}" />                        
+                </Border>
+            </AdornerDecorator>
             <ContentPresenter 
                 x:Name="ContentPresenter"                    
                 Margin="{TemplateBinding Padding}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.ComboBox.xaml
@@ -153,8 +153,14 @@
             </Grid.ColumnDefinitions>
             <Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}" Margin="1" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
                 <Grid MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}" UseLayoutRounding="True">
-                    <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
-                                        Effect="{DynamicResource MaterialDesignShadowDepth2}" />
+                    <AdornerDecorator>
+                        <AdornerDecorator.CacheMode>
+                            <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                        </AdornerDecorator.CacheMode>
+                        <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
+                                Effect="{DynamicResource MaterialDesignShadowDepth2}">
+                        </Border>
+                    </AdornerDecorator>
                     <Border x:Name="dropDownBorder" Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}" Background="Transparent"
                             CornerRadius="2" BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}">
                         <ScrollViewer x:Name="DropDownScrollViewer">
@@ -231,8 +237,14 @@
             </Grid.ColumnDefinitions>
             <Popup x:Name="PART_Popup" AllowsTransparency="true" Grid.ColumnSpan="2" IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom">
                 <Grid MaxHeight="{TemplateBinding MaxDropDownHeight}" MinWidth="{Binding ActualWidth, ElementName=templateRoot}" UseLayoutRounding="True">
-                    <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
-                                        Effect="{DynamicResource MaterialDesignShadowDepth2}" />
+                    <AdornerDecorator>
+                        <AdornerDecorator.CacheMode>
+                            <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                        </AdornerDecorator.CacheMode>
+                        <Border x:Name="shadow" Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2" BorderThickness="1"
+                                                Effect="{DynamicResource MaterialDesignShadowDepth2}">
+                        </Border>
+                    </AdornerDecorator>
                     <Border x:Name="dropDownBorder" Margin="{Binding ElementName=shadow, Path=Margin, Mode=OneWay}" Background="Transparent"
                             CornerRadius="2" BorderThickness="1" BorderBrush="{DynamicResource MaterialDesignDivider}">
                         <ScrollViewer x:Name="DropDownScrollViewer">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -72,10 +72,16 @@
                                PlacementTarget="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type DataGridCell}}}"                                                              
                                PopupAnimation="Fade">
                             <Grid>
-                                <Border Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2"
-                                        Margin="5,5,5,5"
-                                        Effect="{StaticResource MaterialDesignShadowDepth2}"
-                                        BorderThickness="1" />
+                                <AdornerDecorator>
+                                    <AdornerDecorator.CacheMode>
+                                        <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                    </AdornerDecorator.CacheMode>
+                                    <Border Background="{DynamicResource MaterialDesignPaper}" CornerRadius="2"
+                                            Margin="5,5,5,5"
+                                            Effect="{StaticResource MaterialDesignShadowDepth2}"
+                                            BorderThickness="1">
+                                    </Border>
+                                </AdornerDecorator>
                                 <Border Padding="16" Background="Transparent" CornerRadius="2"
                                         Margin="5,5,5,5"
                                         BorderBrush="{DynamicResource MaterialDesignDivider}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -75,10 +75,15 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="{x:Type Calendar}">
-					<Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
-						<CalendarItem x:Name="PART_CalendarItem" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" Style="{DynamicResource MaterialDesignCalendarItemPortrait}"
-									  />	
-					</Border>					
+          <AdornerDecorator>
+              <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+              <AdornerDecorator.CacheMode>
+                  <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+              </AdornerDecorator.CacheMode>
+              <Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
+     			    		<CalendarItem x:Name="PART_CalendarItem" BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" Style="{DynamicResource MaterialDesignCalendarItemPortrait}"/>
+              </Border>					
+            </AdornerDecorator>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -47,22 +47,28 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuBase}">
-                    <Border Background="{TemplateBinding Background}"
-                            Effect="{DynamicResource MaterialDesignShadowDepth1}"
-                            Margin="3"
-                            CornerRadius="2">
-                        <Border Background="Transparent">
-                            <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
-                                <Grid RenderOptions.ClearTypeHint="Enabled" Margin="0 16">
-                                    <ItemsPresenter x:Name="ItemsPresenter"
-                                                            KeyboardNavigation.DirectionalNavigation="Cycle"
-                                                            Grid.IsSharedSizeScope="True"
-                                                            SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
-                                                            KeyboardNavigation.TabNavigation="Cycle"/>
-                                </Grid>
-                            </ScrollViewer>
+                    <AdornerDecorator>
+                        <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+                        <AdornerDecorator.CacheMode>
+                            <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                        </AdornerDecorator.CacheMode>
+                        <Border Background="{TemplateBinding Background}"
+                                Effect="{DynamicResource MaterialDesignShadowDepth1}"
+                                Margin="3"
+                                CornerRadius="2">
+                            <Border Background="Transparent">
+                                <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
+                                    <Grid RenderOptions.ClearTypeHint="Enabled" Margin="0 16">
+                                        <ItemsPresenter x:Name="ItemsPresenter"
+                                                                KeyboardNavigation.DirectionalNavigation="Cycle"
+                                                                Grid.IsSharedSizeScope="True"
+                                                                SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                                                                KeyboardNavigation.TabNavigation="Cycle"/>
+                                    </Grid>
+                                </ScrollViewer>
+                            </Border>
                         </Border>
-                    </Border>
+                    </AdornerDecorator>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -171,10 +177,15 @@
                                IsOpen="{Binding IsSubmenuOpen, RelativeSource={RelativeSource TemplatedParent}}"
                                PopupAnimation="Slide"
                                Placement="Bottom">
+                            <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+                            <Popup.CacheMode>
+                                <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                            </Popup.CacheMode>
                             <Border x:Name="SubMenuBorder"
                                     Background="{Binding Path=Background, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=MenuBase}}"
                                     Effect="{DynamicResource MaterialDesignShadowDepth1}"
                                     CornerRadius="2">
+
                                 <Border Background="Transparent">
                                     <ScrollViewer x:Name="SubMenuScrollViewer" Style="{DynamicResource {ComponentResourceKey ResourceId=MenuScrollViewer, TypeInTargetAssembly={x:Type FrameworkElement}}}">
                                         <Grid RenderOptions.ClearTypeHint="Enabled" Margin="0 16">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -197,9 +197,15 @@
                                                     </VisualState>
                                                 </VisualStateGroup>
                                             </VisualStateManager.VisualStateGroups>
-                                            <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}" 
-                                                     Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:PopupBox}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
-                                                     x:Name="border" />
+                                            <AdornerDecorator>
+                                                <AdornerDecorator.CacheMode>
+                                                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                                </AdornerDecorator.CacheMode>
+                                                <Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding BorderBrush}" StrokeThickness="{TemplateBinding BorderThickness}" 
+                                                                               Effect="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:PopupBox}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                                                               x:Name="border">
+                                                </Ellipse>
+                                            </AdornerDecorator>
                                             <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"  
                                                         Feedback="White"
                                                         Clip="{Binding ElementName=GeometryEllipse, Path=RenderedGeometry}" ClipToBounds="True"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -7,11 +7,10 @@
     <Color x:Key="MaterialDesignShadow">#AA000000</Color>
     <SolidColorBrush x:Key="MaterialDesignShadowBrush" Color="{StaticResource MaterialDesignShadow}"/>
 
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth0" BlurRadius="0" ShadowDepth="0" Direction="270" Opacity="0" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" po:Freeze="True" />
-    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth1" BlurRadius="5" ShadowDepth="1" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth2" BlurRadius="8" ShadowDepth="1.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth3" BlurRadius="14" ShadowDepth="4.5" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth4" BlurRadius="25" ShadowDepth="8" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
+    <DropShadowEffect x:Key="MaterialDesignShadowDepth5" BlurRadius="35" ShadowDepth="13" Direction="270" Color="{StaticResource MaterialDesignShadow}" Opacity=".42" RenderingBias="Performance" po:Freeze="True" />
 	
 </ResourceDictionary>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TimePicker.xaml
@@ -22,9 +22,16 @@
 						<Setter Property="Template">
 							<Setter.Value>
 								<ControlTemplate TargetType="{x:Type ContentControl}">
-									<Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
-										<ContentPresenter Content="{TemplateBinding ContentControl.Content}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
-									</Border>
+                    <AdornerDecorator>
+                        <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+                        <AdornerDecorator.CacheMode>
+                            <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                        </AdornerDecorator.CacheMode>
+
+                        <Border Effect="{DynamicResource MaterialDesignShadowDepth4}" Padding="16 8 16 24">
+                            <ContentPresenter Content="{TemplateBinding ContentControl.Content}" ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}" />
+									      </Border>
+                    </AdornerDecorator>
 								</ControlTemplate>
 							</Setter.Value>
 						</Setter>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToggleButton.xaml
@@ -354,13 +354,19 @@
                                         <ScaleTransform ScaleX="1" ScaleY="1"/>
                                     </Ellipse.RenderTransform>
                                 </Ellipse>
-                                <Ellipse x:Name="Thumb"
-                                         Fill="#FFFAFAFA" Stroke="{x:Null}" 
-                                         HorizontalAlignment="Center" VerticalAlignment="Center"
-                                         Width="25" Height="25"
-                                         Margin="0,0,0,0"
-                                         RenderTransformOrigin="0.5,0.5"
-                                         Effect="{DynamicResource MaterialDesignShadowDepth1}"/>
+                                <AdornerDecorator>
+                                    <AdornerDecorator.CacheMode>
+                                        <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                    </AdornerDecorator.CacheMode>
+                                    <Ellipse x:Name="Thumb"
+                                             Fill="#FFFAFAFA" Stroke="{x:Null}" 
+                                             HorizontalAlignment="Center" VerticalAlignment="Center"
+                                             Width="25" Height="25"
+                                             Margin="0,0,0,0"
+                                             RenderTransformOrigin="0.5,0.5"
+                                             Effect="{DynamicResource MaterialDesignShadowDepth1}">
+                                    </Ellipse>
+                                </AdornerDecorator>
                                 <Grid.RenderTransform>
                                     <TranslateTransform X="0" Y="0"/>
                                 </Grid.RenderTransform>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -129,6 +129,10 @@
                                           Foreground="{TemplateBinding Foreground}"
                                           />
                             <Popup x:Name="OverflowPopup" AllowsTransparency="true" Focusable="false" IsOpen="{Binding IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom" StaysOpen="false" Margin="1">
+                                <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+                                <Popup.CacheMode>
+                                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                </Popup.CacheMode>
                                 <Border x:Name="ToolBarSubMenuBorder" BorderBrush="{DynamicResource MaterialDesignDivider}" BorderThickness="1" Background="{DynamicResource MaterialDesignPaper}"
                                                 TextBlock.FontWeight="ExtraBold"
                                                 CornerRadius="2" Margin="1"


### PR DESCRIPTION
Basically added decorators with the cache mode enabled wrapping elements with associated shadow effects wherever possible in order to speed up performance by a lot. Its effects can be seen on the flyout animations of the demo app for example.