### PR TITLE
call PasswordBoxOnPasswordChanged after initialization

### DIFF
--- a/MaterialDesignThemes.Wpf/PasswordFieldAssist.cs
+++ b/MaterialDesignThemes.Wpf/PasswordFieldAssist.cs
@@ -17,13 +17,14 @@ namespace MaterialDesignThemes.Wpf
             if (passwordBox != null)
             {
                 passwordBox.PasswordChanged -= PasswordBoxOnPasswordChanged;
+                passwordBox.Loaded -= PasswordBoxOnPasswordChanged;
             }
 
             passwordBox = dependencyPropertyChangedEventArgs.NewValue as PasswordBox;
             if (passwordBox != null)
             {
                 passwordBox.PasswordChanged += PasswordBoxOnPasswordChanged;
-                ConfigureHint(passwordBox);
+                passwordBox.Loaded += PasswordBoxOnPasswordChanged;
             }
         }
 
@@ -89,10 +90,5 @@ namespace MaterialDesignThemes.Wpf
             return (bool)element.GetValue(IsNullOrEmptyProperty);
         }
     }
-
-    public static class ProgressBarAssist
-    {
-
-
-    }
+    
 }


### PR DESCRIPTION
to support passwordboxes which are initially not empty
fixes #213