### PR TITLE
set PasswordBox HorizontalContentAlignment and VerticalContentAlignme…

### DIFF
--- a/MainDemo.Wpf/TextFields.xaml
+++ b/MainDemo.Wpf/TextFields.xaml
@@ -19,7 +19,9 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MaterialDesignTextBox}">
-                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="Margin" Value="0 8 0 8" />
+            </Style>
+            <Style TargetType="{x:Type PasswordBox}" BasedOn="{StaticResource MaterialDesignPasswordBox}">
                 <Setter Property="Margin" Value="0 8 0 8" />
             </Style>
             <Style TargetType="{x:Type ComboBox}" BasedOn="{StaticResource MaterialDesignComboBox}">

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -16,8 +16,8 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="CaretBrush" Value="{Binding RelativeSource={RelativeSource Self}, Path=BorderBrush}"/>
         <Setter Property="KeyboardNavigation.TabNavigation" Value="None"/>
-        <Setter Property="HorizontalContentAlignment" Value="Left"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+        <Setter Property="VerticalContentAlignment" Value="Stretch"/>
         <Setter Property="FocusVisualStyle" Value="{x:Null}"/>
         <Setter Property="AllowDrop" Value="true"/>
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst"/>
@@ -27,23 +27,23 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type PasswordBox}">
-                    <Grid VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                    <Grid>
                         <Border x:Name="border"
                                 BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
                                 Background="{TemplateBinding Background}"
                                 SnapsToDevicePixels="True"
-                                Padding="0 4 0 4" VerticalAlignment="Center">
-                            <Grid Margin="{TemplateBinding Padding}">
-                                <ScrollViewer x:Name="PART_ContentHost"
-                                              Focusable="false"
-                                              HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
-                                              TextElement.FontFamily="Times New Roman" />
+                                Padding="0 4 0 4">
+                            <Grid Margin="{TemplateBinding Padding}"
+                                  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+                                <ScrollViewer x:Name="PART_ContentHost" Focusable="false" HorizontalScrollBarVisibility="Hidden" VerticalScrollBarVisibility="Hidden"
+                                              />
                                 <TextBlock Text="{Binding Path=(wpf:TextFieldAssist.Hint), RelativeSource={RelativeSource TemplatedParent}}"
-                                                   Visibility="{Binding Path=(wpf:PasswordFieldAssist.HintVisibility), RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
-                                                   Margin="1 0 1 0"
+                                           Visibility="{Binding Path=(wpf:PasswordFieldAssist.HintVisibility), RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay}"
                                            IsHitTestVisible="False"
-                                                   x:Name="Hint"
-                                                   Opacity="{Binding Path=(wpf:TextFieldAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
+                                           x:Name="Hint"
+                                           Margin="1 0 1 0"
+                                           Opacity="{Binding Path=(wpf:TextFieldAssist.HintOpacity), RelativeSource={RelativeSource TemplatedParent}}" />
                             </Grid>
                         </Border>
                         <wpf:Underline x:Name="Underline"/>


### PR DESCRIPTION
…nt to Stretch
which displays the mouse cursor as IBeam over the complete passwordbox

Without this fix:
![image](https://cloud.githubusercontent.com/assets/4009570/12337305/7af753b6-bb09-11e5-8e5a-6101570d4966.png)

With this fix:
![image](https://cloud.githubusercontent.com/assets/4009570/12337258/426bcd06-bb09-11e5-8e95-e7c0a47df154.png)

This fix also aligns the differences between `MaterialDesignTheme.PasswordBox.xaml` and  `MaterialDesignTheme.TextBox.xaml`.