### PR TITLE
Fix crash when DatePicker value is invalid

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DatePicker.xaml
@@ -189,7 +189,7 @@
 						</Trigger>
 						<Trigger Property="Validation.HasError" Value="true">
 							<Setter Property="BorderBrush" Value="{DynamicResource ValidationErrorBrush}"/>
-                            <Setter TargetName="Underline" Property="IsActive" Value="{DynamicResource ValidationErrorBrush}"/>
+                            <Setter TargetName="Underline" Property="Background" Value="{DynamicResource ValidationErrorBrush}"/>
 						</Trigger>
 					</ControlTemplate.Triggers>
 				</ControlTemplate>


### PR DESCRIPTION
An InvalidCastException was thrown on any validation errors