### PR TITLE
nameof(...) according to MSDN; usings removed

### DIFF
--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
@@ -14,7 +9,7 @@ namespace MaterialDesignThemes.Wpf
     public class ComboBoxPopup : Popup
     {
         public static readonly DependencyProperty UpContentTemplateProperty
-            = DependencyProperty.Register(nameof(UpContentTemplateProperty),
+            = DependencyProperty.Register(nameof(UpContentTemplate),
                 typeof(ControlTemplate),
                 typeof(ComboBoxPopup),
                 new UIPropertyMetadata(null));
@@ -26,7 +21,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DownContentTemplateProperty
-            = DependencyProperty.Register(nameof(DownContentTemplateProperty),
+            = DependencyProperty.Register(nameof(DownContentTemplate),
                 typeof(ControlTemplate),
                 typeof(ComboBoxPopup),
                 new UIPropertyMetadata(null));
@@ -38,7 +33,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DefaultContentTemplateProperty
-            = DependencyProperty.Register(nameof(DefaultContentTemplateProperty),
+            = DependencyProperty.Register(nameof(DefaultContentTemplate),
                 typeof(ControlTemplate),
                 typeof(ComboBoxPopup),
                 new UIPropertyMetadata(null));
@@ -50,7 +45,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty UpVerticalOffsetProperty
-            = DependencyProperty.Register(nameof(UpVerticalOffsetProperty),
+            = DependencyProperty.Register(nameof(UpVerticalOffset),
                 typeof(double),
                 typeof(ComboBoxPopup),
                 new PropertyMetadata(0.0));
@@ -62,7 +57,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DownVerticalOffsetProperty
-            = DependencyProperty.Register(nameof(DownVerticalOffsetProperty),
+            = DependencyProperty.Register(nameof(DownVerticalOffset),
                 typeof(double),
                 typeof(ComboBoxPopup),
                 new PropertyMetadata(0.0));
@@ -74,7 +69,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DefaultVerticalOffsetProperty
-            = DependencyProperty.Register(nameof(DefaultVerticalOffsetProperty),
+            = DependencyProperty.Register(nameof(DefaultVerticalOffset),
                 typeof(double),
                 typeof(ComboBoxPopup),
                 new PropertyMetadata(0.0));


### PR DESCRIPTION
https://msdn.microsoft.com/library/dn986596.aspx

It makes more sense to use the property and not the DependencyProperty
name as the argument of nameof. Also this is what Microsoft does.