### PR TITLE
Uses C#6 nameof feature to improve maintainability

### DIFF
--- a/MaterialDesignThemes.Wpf/Card.cs
+++ b/MaterialDesignThemes.Wpf/Card.cs
@@ -49,7 +49,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty UniformCornerRadiusProperty = DependencyProperty.Register(
-            "UniformCornerRadius", typeof (double), typeof (Card), new FrameworkPropertyMetadata(2.0, FrameworkPropertyMetadataOptions.AffectsMeasure));
+            nameof(UniformCornerRadius), typeof (double), typeof (Card), new FrameworkPropertyMetadata(2.0, FrameworkPropertyMetadataOptions.AffectsMeasure));
 
         public double UniformCornerRadius
         {

--- a/MaterialDesignThemes.Wpf/Clock.cs
+++ b/MaterialDesignThemes.Wpf/Clock.cs
@@ -65,7 +65,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty TimeProperty = DependencyProperty.Register(
-			"Time", typeof (DateTime), typeof (Clock), new FrameworkPropertyMetadata(default(DateTime), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, TimePropertyChangedCallback));
+            nameof(Time), typeof (DateTime), typeof (Clock), new FrameworkPropertyMetadata(default(DateTime), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, TimePropertyChangedCallback));
 
 	    private static void TimePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
@@ -108,7 +108,7 @@ namespace MaterialDesignThemes.Wpf
 	    }	    
 
 		public static readonly DependencyProperty IsPostMeridiemProperty = DependencyProperty.Register(
-			"IsPostMeridiem", typeof (bool), typeof (Clock), new PropertyMetadata(default(bool), IsPostMeridiemPropertyChangedCallback));
+            nameof(IsPostMeridiem), typeof (bool), typeof (Clock), new PropertyMetadata(default(bool), IsPostMeridiemPropertyChangedCallback));
 
 		private static void IsPostMeridiemPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
@@ -126,7 +126,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 	    public static readonly DependencyProperty Is24HoursProperty = DependencyProperty.Register(
-	        "Is24Hours", typeof (bool), typeof (Clock), new PropertyMetadata(default(bool)));
+            nameof(Is24Hours), typeof (bool), typeof (Clock), new PropertyMetadata(default(bool)));
 
 	    public bool Is24Hours
 	    {
@@ -136,7 +136,7 @@ namespace MaterialDesignThemes.Wpf
 
 
 		public static readonly DependencyProperty DisplayModeProperty = DependencyProperty.Register(
-			"DisplayMode", typeof (ClockDisplayMode), typeof (Clock), new FrameworkPropertyMetadata(ClockDisplayMode.Hours, DisplayModePropertyChangedCallback));
+            nameof(DisplayMode), typeof (ClockDisplayMode), typeof (Clock), new FrameworkPropertyMetadata(ClockDisplayMode.Hours, DisplayModePropertyChangedCallback));
 
 	    private static void DisplayModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 	    {
@@ -150,7 +150,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty DisplayAutomationProperty = DependencyProperty.Register(
-			"DisplayAutomation", typeof (ClockDisplayAutomation), typeof (Clock), new PropertyMetadata(default(ClockDisplayAutomation)));
+            nameof(DisplayAutomation), typeof (ClockDisplayAutomation), typeof (Clock), new PropertyMetadata(default(ClockDisplayAutomation)));
 
 		public ClockDisplayAutomation DisplayAutomation
 		{
@@ -159,7 +159,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty ButtonStyleProperty = DependencyProperty.Register(
-			"ButtonStyle", typeof (Style), typeof (Clock), new PropertyMetadata(default(Style)));		
+            nameof(ButtonStyle), typeof (Style), typeof (Clock), new PropertyMetadata(default(Style)));
 
 		public Style ButtonStyle
 		{
@@ -168,7 +168,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty LesserButtonStyleProperty = DependencyProperty.Register(
-			"LesserButtonStyle", typeof (Style), typeof (Clock), new PropertyMetadata(default(Style)));
+            nameof(LesserButtonStyle), typeof (Style), typeof (Clock), new PropertyMetadata(default(Style)));
 
 		public Style LesserButtonStyle
 		{
@@ -177,7 +177,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty ButtonRadiusRatioProperty = DependencyProperty.Register(
-			"ButtonRadiusRatio", typeof (double), typeof (Clock), new PropertyMetadata(default(double)));
+            nameof(ButtonRadiusRatio), typeof (double), typeof (Clock), new PropertyMetadata(default(double)));
 
 		public double ButtonRadiusRatio
 		{
@@ -186,7 +186,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 	    public static readonly DependencyProperty ButtonRadiusInnerRatioProperty = DependencyProperty.Register(
-	        "ButtonRadiusInnerRatio", typeof (double), typeof (Clock), new PropertyMetadata(default(double)));
+            nameof(ButtonRadiusInnerRatio), typeof (double), typeof (Clock), new PropertyMetadata(default(double)));
 
 	    public double ButtonRadiusInnerRatio
 	    {

--- a/MaterialDesignThemes.Wpf/ClockItemButton.cs
+++ b/MaterialDesignThemes.Wpf/ClockItemButton.cs
@@ -12,7 +12,7 @@ namespace MaterialDesignThemes.Wpf
 		public const string ThumbPartName = "PART_Thumb";
 		
 		public static readonly DependencyProperty CentreXProperty = DependencyProperty.Register(
-			"CentreX", typeof (double), typeof (ClockItemButton), new PropertyMetadata(default(double)));
+            nameof(CentreX), typeof (double), typeof (ClockItemButton), new PropertyMetadata(default(double)));
 
 		public double CentreX
 		{
@@ -21,7 +21,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty CentreYProperty = DependencyProperty.Register(
-			"CentreY", typeof (double), typeof (ClockItemButton), new PropertyMetadata(default(double)));
+            nameof(CentreY), typeof (double), typeof (ClockItemButton), new PropertyMetadata(default(double)));
 
 		public double CentreY
 		{

--- a/MaterialDesignThemes.Wpf/ColorZone.cs
+++ b/MaterialDesignThemes.Wpf/ColorZone.cs
@@ -38,7 +38,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ModeProperty = DependencyProperty.Register(
-            "Mode", typeof (ColorZoneMode), typeof (ColorZone), new PropertyMetadata(default(ColorZoneMode)));
+            nameof(Mode), typeof (ColorZoneMode), typeof (ColorZone), new PropertyMetadata(default(ColorZoneMode)));
 
         public ColorZoneMode Mode
         {
@@ -47,7 +47,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty CornerRadiusProperty = DependencyProperty.Register(
-            "CornerRadius", typeof (CornerRadius), typeof (ColorZone), new PropertyMetadata(default(CornerRadius)));
+            nameof(CornerRadius), typeof (CornerRadius), typeof (ColorZone), new PropertyMetadata(default(CornerRadius)));
 
         public CornerRadius CornerRadius
         {

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -210,7 +210,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty IdentifierProperty = DependencyProperty.Register(
-            "Identifier", typeof (object), typeof (DialogHost), new PropertyMetadata(default(object)));
+            nameof(Identifier), typeof (object), typeof (DialogHost), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// Identifier which is used in conjunction with <see cref="Show(object)"/> to determine where a dialog should be shown.
@@ -222,7 +222,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty IsOpenProperty = DependencyProperty.Register(
-            "IsOpen", typeof (bool), typeof (DialogHost), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsOpenPropertyChangedCallback));        
+            nameof(IsOpen), typeof (bool), typeof (DialogHost), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsOpenPropertyChangedCallback));
 
         private static void IsOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
@@ -281,7 +281,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DialogContentProperty = DependencyProperty.Register(
-            "DialogContent", typeof (object), typeof (DialogHost), new PropertyMetadata(default(object)));
+            nameof(DialogContent), typeof (object), typeof (DialogHost), new PropertyMetadata(default(object)));
 
         public object DialogContent
         {
@@ -290,7 +290,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DialogContentTemplateProperty = DependencyProperty.Register(
-            "DialogContentTemplate", typeof (DataTemplate), typeof (DialogHost), new PropertyMetadata(default(DataTemplate)));
+            nameof(DialogContentTemplate), typeof (DataTemplate), typeof (DialogHost), new PropertyMetadata(default(DataTemplate)));
 
         public DataTemplate DialogContentTemplate
         {
@@ -299,7 +299,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DialogContentTemplateSelectorProperty = DependencyProperty.Register(
-            "DialogContentTemplateSelector", typeof (DataTemplateSelector), typeof (DialogHost), new PropertyMetadata(default(DataTemplateSelector)));
+            nameof(DialogContentTemplateSelector), typeof (DataTemplateSelector), typeof (DialogHost), new PropertyMetadata(default(DataTemplateSelector)));
 
         public DataTemplateSelector DialogContentTemplateSelector
         {
@@ -308,7 +308,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DialogContentStringFormatProperty = DependencyProperty.Register(
-            "DialogContentStringFormat", typeof (string), typeof (DialogHost), new PropertyMetadata(default(string)));
+            nameof(DialogContentStringFormat), typeof (string), typeof (DialogHost), new PropertyMetadata(default(string)));
 
         public string DialogContentStringFormat
         {
@@ -317,7 +317,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty OpenDialogCommandDataContextSourceProperty = DependencyProperty.Register(
-            "OpenDialogCommandDataContextSource", typeof (DialogHostOpenDialogCommandDataContextSource), typeof (DialogHost), new PropertyMetadata(default(DialogHostOpenDialogCommandDataContextSource)));
+            nameof(OpenDialogCommandDataContextSource), typeof (DialogHostOpenDialogCommandDataContextSource), typeof (DialogHost), new PropertyMetadata(default(DialogHostOpenDialogCommandDataContextSource)));
 
         /// <summary>
         /// Defines how a data context is sourced for a dialog if a <see cref="FrameworkElement"/>
@@ -374,7 +374,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DialogOpenedCallbackProperty = DependencyProperty.Register(
-            "DialogOpenedCallback", typeof(DialogOpenedEventHandler), typeof(DialogHost), new PropertyMetadata(default(DialogOpenedEventHandler)));
+            nameof(DialogOpenedCallback), typeof(DialogOpenedEventHandler), typeof(DialogHost), new PropertyMetadata(default(DialogOpenedEventHandler)));
 
         /// <summary>
         /// Callback fired when the <see cref="DialogOpened"/> event is fired, allowing the event to be processed from a binding/view model.
@@ -427,7 +427,7 @@ namespace MaterialDesignThemes.Wpf
         }        
 
         public static readonly DependencyProperty DialogClosingCallbackProperty = DependencyProperty.Register(
-            "DialogClosingCallback", typeof (DialogClosingEventHandler), typeof (DialogHost), new PropertyMetadata(default(DialogClosingEventHandler)));        
+            nameof(DialogClosingCallback), typeof (DialogClosingEventHandler), typeof (DialogHost), new PropertyMetadata(default(DialogClosingEventHandler)));
 
         /// <summary>
         /// Callback fired when the <see cref="DialogClosing"/> event is fired, allowing the event to be processed from a binding/view model.

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -39,7 +39,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty LeftDrawerContentProperty = DependencyProperty.Register(
-            "LeftDrawerContent", typeof (object), typeof (DrawerHost), new PropertyMetadata(default(object)));
+            nameof(LeftDrawerContent), typeof (object), typeof (DrawerHost), new PropertyMetadata(default(object)));
 
         public object LeftDrawerContent
         {
@@ -48,7 +48,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty LeftDrawerContentTemplateProperty = DependencyProperty.Register(
-            "LeftDrawerContentTemplate", typeof (DataTemplate), typeof (DrawerHost), new PropertyMetadata(default(DataTemplate)));
+            nameof(LeftDrawerContentTemplate), typeof (DataTemplate), typeof (DrawerHost), new PropertyMetadata(default(DataTemplate)));
 
         public DataTemplate LeftDrawerContentTemplate
         {
@@ -57,7 +57,7 @@ namespace MaterialDesignThemes.Wpf
         }
         
         public static readonly DependencyProperty LeftDrawerContentTemplateSelectorProperty = DependencyProperty.Register(
-            "LeftDrawerContentTemplateSelector", typeof (DataTemplateSelector), typeof (DrawerHost), new PropertyMetadata(default(DataTemplateSelector)));
+            nameof(LeftDrawerContentTemplateSelector), typeof (DataTemplateSelector), typeof (DrawerHost), new PropertyMetadata(default(DataTemplateSelector)));
 
         public DataTemplateSelector LeftDrawerContentTemplateSelector
         {
@@ -66,7 +66,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty LeftDrawerContentStringFormatProperty = DependencyProperty.Register(
-            "LeftDrawerContentStringFormat", typeof (string), typeof (DrawerHost), new PropertyMetadata(default(string)));
+            nameof(LeftDrawerContentStringFormat), typeof (string), typeof (DrawerHost), new PropertyMetadata(default(string)));
 
         public string LeftDrawerContentStringFormat
         {
@@ -75,7 +75,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty LeftDrawerBackgroundProperty = DependencyProperty.Register(
-            "LeftDrawerBackground", typeof (Brush), typeof (DrawerHost), new PropertyMetadata(default(Brush)));
+            nameof(LeftDrawerBackground), typeof (Brush), typeof (DrawerHost), new PropertyMetadata(default(Brush)));
 
         public Brush LeftDrawerBackground
         {
@@ -84,7 +84,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty IsLeftDrawerOpenProperty = DependencyProperty.Register(
-            "IsLeftDrawerOpen", typeof (bool), typeof (DrawerHost), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsLeftDrawerOpenPropertyChangedCallback));        
+            nameof(IsLeftDrawerOpen), typeof (bool), typeof (DrawerHost), new FrameworkPropertyMetadata(default(bool), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, IsLeftDrawerOpenPropertyChangedCallback));
 
         public bool IsLeftDrawerOpen
         {

--- a/MaterialDesignThemes.Wpf/Icon.cs
+++ b/MaterialDesignThemes.Wpf/Icon.cs
@@ -13,7 +13,7 @@ namespace MaterialDesignThemes.Wpf
     public class Icon : Control
     {
         public static readonly DependencyProperty TypeProperty = DependencyProperty.Register(
-            "Type", typeof (IconType), typeof (Icon), new PropertyMetadata(default(IconType)));
+            nameof(Type), typeof (IconType), typeof (Icon), new PropertyMetadata(default(IconType)));
 
         /// <summary>
         /// Gets or sets the name of icon being displayed.

--- a/MaterialDesignThemes.Wpf/ListSortDirectionIndicator.cs
+++ b/MaterialDesignThemes.Wpf/ListSortDirectionIndicator.cs
@@ -30,7 +30,7 @@ namespace MaterialDesignThemes.Wpf
 
 
         public static readonly DependencyProperty ListSortDirectionProperty = DependencyProperty.Register(
-            "ListSortDirection", typeof (ListSortDirection?), typeof (ListSortDirectionIndicator), new PropertyMetadata(default(ListSortDirection?), ListSortDirectionPropertyChangedCallback));
+            nameof(ListSortDirection), typeof (ListSortDirection?), typeof (ListSortDirectionIndicator), new PropertyMetadata(default(ListSortDirection?), ListSortDirectionPropertyChangedCallback));
 
         private static void ListSortDirectionPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {

--- a/MaterialDesignThemes.Wpf/MaterialDateDisplay.cs
+++ b/MaterialDesignThemes.Wpf/MaterialDateDisplay.cs
@@ -43,7 +43,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty DisplayDateProperty = DependencyProperty.Register(
-            "DisplayDate", typeof (DateTime), typeof (MaterialDateDisplay), new PropertyMetadata(default(DateTime), DisplayDatePropertyChangedCallback));
+            nameof(DisplayDate), typeof (DateTime), typeof (MaterialDateDisplay), new PropertyMetadata(default(DateTime), DisplayDatePropertyChangedCallback));
 
         private static void DisplayDatePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -119,7 +119,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleContentProperty = DependencyProperty.Register(
-            "ToggleContent", typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
+            nameof(ToggleContent), typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// Content to display in the toggle button.
@@ -131,7 +131,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleContentTemplateProperty = DependencyProperty.Register(
-            "ToggleContentTemplate", typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
+            nameof(ToggleContentTemplate), typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
 
         /// <summary>
         /// Template for <see cref="ToggleContent"/>.
@@ -143,7 +143,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleCheckedContentProperty = DependencyProperty.Register(
-            "ToggleCheckedContent", typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
+            nameof(ToggleCheckedContent), typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// Content to display in the toggle when it's checked (when the popup is open). Optional; if not provided the <see cref="ToggleContent"/> is used.
@@ -155,7 +155,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleCheckedContentTemplateProperty = DependencyProperty.Register(
-            "ToggleCheckedContentTemplate", typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
+            nameof(ToggleCheckedContentTemplate), typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
 
         /// <summary>
         /// Template for <see cref="ToggleCheckedContent"/>.
@@ -167,7 +167,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleCheckedContentCommandProperty = DependencyProperty.Register(
-            "ToggleCheckedContentCommand", typeof (ICommand), typeof (PopupBox), new PropertyMetadata(default(ICommand)));
+            nameof(ToggleCheckedContentCommand), typeof (ICommand), typeof (PopupBox), new PropertyMetadata(default(ICommand)));
 
         /// <summary>
         /// Command to execute if toggle is checked (popup is open) and <see cref="ToggleCheckedContent"/> is set.
@@ -179,7 +179,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ToggleCheckedContentCommandParameterProperty = DependencyProperty.Register(
-            "ToggleCheckedContentCommandParameter", typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
+            nameof(ToggleCheckedContentCommandParameter), typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// Command parameter to use in conjunction with <see cref="ToggleCheckedContentCommand"/>.
@@ -191,7 +191,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty PopupContentProperty = DependencyProperty.Register(
-            "PopupContent", typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
+            nameof(PopupContent), typeof (object), typeof (PopupBox), new PropertyMetadata(default(object)));
 
         /// <summary>
         /// Content to display in the content.
@@ -203,7 +203,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty PopupContentTemplateProperty = DependencyProperty.Register(
-            "PopupContentTemplate", typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
+            nameof(PopupContentTemplate), typeof (DataTemplate), typeof (PopupBox), new PropertyMetadata(default(DataTemplate)));
 
         /// <summary>
         /// Popup content template.
@@ -215,7 +215,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty StaysOpenOnEditProperty = DependencyProperty.Register(
-            "StaysOpenOnEdit", typeof (bool), typeof (PopupBox), new PropertyMetadata(default(bool)));
+            nameof(StaysOpenOnEdit), typeof (bool), typeof (PopupBox), new PropertyMetadata(default(bool)));
 
         /// <summary>
         /// Indicates if the opup should stay open after a click is made inside the popup.
@@ -227,7 +227,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty IsPopupOpenProperty = DependencyProperty.Register(
-            "IsPopupOpen", typeof (bool), typeof (PopupBox), new FrameworkPropertyMetadata(default(bool), IsPopupOpenPropertyChangedCallback));
+            nameof(IsPopupOpen), typeof (bool), typeof (PopupBox), new FrameworkPropertyMetadata(default(bool), IsPopupOpenPropertyChangedCallback));
 
         private static void IsPopupOpenPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
@@ -258,7 +258,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty StaysOpenProperty = DependencyProperty.Register(
-            "StaysOpen", typeof (bool), typeof (PopupBox), new PropertyMetadata(default(bool)));
+            nameof(StaysOpen), typeof (bool), typeof (PopupBox), new PropertyMetadata(default(bool)));
 
         /// <summary>
         /// Indicates of the popup should stay open if a click occurs inside the popup.
@@ -270,7 +270,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty PlacementModeProperty = DependencyProperty.Register(
-            "PlacementMode", typeof (PopupBoxPlacementMode), typeof (PopupBox), new PropertyMetadata(default(PopupBoxPlacementMode), PlacementModePropertyChangedCallback));
+            nameof(PlacementMode), typeof (PopupBoxPlacementMode), typeof (PopupBox), new PropertyMetadata(default(PopupBoxPlacementMode), PlacementModePropertyChangedCallback));
 
         private static void PlacementModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
@@ -287,7 +287,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty PopupModeProperty = DependencyProperty.Register(
-            "PopupMode", typeof (PopupBoxPopupMode), typeof (PopupBox), new PropertyMetadata(default(PopupBoxPopupMode)));        
+            nameof(PopupMode), typeof (PopupBoxPopupMode), typeof (PopupBox), new PropertyMetadata(default(PopupBoxPopupMode)));
 
         /// <summary>
         /// Gets or sets what trigger causes the popup to open.
@@ -302,7 +302,7 @@ namespace MaterialDesignThemes.Wpf
         /// Get or sets how to unfurl controls when opening the popups. Only child elements of type <see cref="ButtonBase"/> are animated.
         /// </summary>
         public static readonly DependencyProperty UnfurlOrientationProperty = DependencyProperty.Register(
-            "UnfurlOrientation", typeof (Orientation), typeof (PopupBox), new PropertyMetadata(Orientation.Vertical));
+            nameof(UnfurlOrientation), typeof (Orientation), typeof (PopupBox), new PropertyMetadata(Orientation.Vertical));
 
         /// <summary>
         /// Gets or sets how to unfurl controls when opening the popups. Only child elements of type <see cref="ButtonBase"/> are animated.

--- a/MaterialDesignThemes.Wpf/RatingBar.cs
+++ b/MaterialDesignThemes.Wpf/RatingBar.cs
@@ -42,7 +42,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty MinProperty = DependencyProperty.Register(
-            "Min", typeof (int), typeof (RatingBar), new PropertyMetadata(1, MinPropertyChangedCallback));        
+            nameof(Min), typeof (int), typeof (RatingBar), new PropertyMetadata(1, MinPropertyChangedCallback));
 
         public int Min
         {
@@ -51,7 +51,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty MaxProperty = DependencyProperty.Register(
-            "Max", typeof (int), typeof (RatingBar), new PropertyMetadata(5, MaxPropertyChangedCallback));
+            nameof(Max), typeof (int), typeof (RatingBar), new PropertyMetadata(5, MaxPropertyChangedCallback));
 
         public int Max
         {
@@ -60,7 +60,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
-            "Value", typeof (int), typeof (RatingBar), new PropertyMetadata(0, ValuePropertyChangedCallback));
+            nameof(Value), typeof (int), typeof (RatingBar), new PropertyMetadata(0, ValuePropertyChangedCallback));
 
         private static void ValuePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {
@@ -77,7 +77,7 @@ namespace MaterialDesignThemes.Wpf
         public ReadOnlyObservableCollection<RatingBarButton> RatingButtons => _ratingButtons;
 
         public static readonly DependencyProperty ValueItemContainerButtonStyleProperty = DependencyProperty.Register(
-            "ValueItemContainerButtonStyle", typeof (Style), typeof (RatingBar), new PropertyMetadata(default(Style)));
+            nameof(ValueItemContainerButtonStyle), typeof (Style), typeof (RatingBar), new PropertyMetadata(default(Style)));
 
         public Style ValueItemContainerButtonStyle
         {
@@ -86,7 +86,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ValueItemTemplateProperty = DependencyProperty.Register(
-            "ValueItemTemplate", typeof (DataTemplate), typeof (RatingBar), new PropertyMetadata(default(DataTemplate)));
+            nameof(ValueItemTemplate), typeof (DataTemplate), typeof (RatingBar), new PropertyMetadata(default(DataTemplate)));
 
         public DataTemplate ValueItemTemplate
         {
@@ -95,7 +95,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty ValueItemTemplateSelectorProperty = DependencyProperty.Register(
-            "ValueItemTemplateSelector", typeof (DataTemplateSelector), typeof (RatingBar), new PropertyMetadata(default(DataTemplateSelector)));
+            nameof(ValueItemTemplateSelector), typeof (DataTemplateSelector), typeof (RatingBar), new PropertyMetadata(default(DataTemplateSelector)));
 
         public DataTemplateSelector ValueItemTemplateSelector
         {
@@ -104,7 +104,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty OrientationProperty = DependencyProperty.Register(
-            "Orientation", typeof (Orientation), typeof (RatingBar), new PropertyMetadata(default(Orientation)));
+            nameof(Orientation), typeof (Orientation), typeof (RatingBar), new PropertyMetadata(default(Orientation)));
 
         public Orientation Orientation
         {

--- a/MaterialDesignThemes.Wpf/Ripple.cs
+++ b/MaterialDesignThemes.Wpf/Ripple.cs
@@ -79,7 +79,7 @@ namespace MaterialDesignThemes.Wpf
         }        
 
         public static readonly DependencyProperty FeedbackProperty = DependencyProperty.Register(
-            "Feedback", typeof(Brush), typeof(Ripple), new PropertyMetadata(default(Brush)));
+            nameof(Feedback), typeof(Brush), typeof(Ripple), new PropertyMetadata(default(Brush)));
 
         public Brush Feedback
         {
@@ -170,7 +170,7 @@ namespace MaterialDesignThemes.Wpf
         /// </summary> 
         public static readonly DependencyProperty RecognizesAccessKeyProperty =
             DependencyProperty.Register(
-                "RecognizesAccessKey", typeof(bool), typeof(Ripple),
+                nameof(RecognizesAccessKey), typeof(bool), typeof(Ripple),
                 new PropertyMetadata(default(bool)));
 
         /// <summary> 

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -45,7 +45,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty TextProperty = DependencyProperty.Register(
-			"Text", typeof (string), typeof (TimePicker), new PropertyMetadata(default(string), TextPropertyChangedCallback));
+            nameof(Text), typeof (string), typeof (TimePicker), new PropertyMetadata(default(string), TextPropertyChangedCallback));
 
 		private static void TextPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
@@ -62,7 +62,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty SelectedTimeProperty = DependencyProperty.Register(
-			"SelectedTime", typeof (DateTime?), typeof (TimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedTimePropertyChangedCallback));
+            nameof(SelectedTime), typeof (DateTime?), typeof (TimePicker), new FrameworkPropertyMetadata(default(DateTime?), FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, SelectedTimePropertyChangedCallback));
 
 		private static void SelectedTimePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
@@ -77,7 +77,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty SelectedTimeFormatProperty = DependencyProperty.Register(
-			"SelectedTimeFormat", typeof (DatePickerFormat), typeof (TimePicker), new PropertyMetadata(DatePickerFormat.Short));
+            nameof(SelectedTimeFormat), typeof (DatePickerFormat), typeof (TimePicker), new PropertyMetadata(DatePickerFormat.Short));
 
 		public DatePickerFormat SelectedTimeFormat
 		{
@@ -86,7 +86,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty IsDropDownOpenProperty = DependencyProperty.Register(
-			"IsDropDownOpen", typeof (bool), typeof (TimePicker),
+            nameof(IsDropDownOpen), typeof (bool), typeof (TimePicker),
 			new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnIsDropDownOpenChanged, OnCoerceIsDropDownOpen));
 
 		public bool IsDropDownOpen
@@ -96,7 +96,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 	    public static readonly DependencyProperty Is24HoursProperty = DependencyProperty.Register(
-	        "Is24Hours", typeof (bool), typeof (TimePicker), new PropertyMetadata(default(bool)));
+            nameof(Is24Hours), typeof (bool), typeof (TimePicker), new PropertyMetadata(default(bool)));
 
 	    public bool Is24Hours
 	    {
@@ -142,7 +142,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty ClockStyleProperty = DependencyProperty.Register(
-			"ClockStyle", typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
+            nameof(ClockStyle), typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
 
 		public Style ClockStyle
 		{
@@ -151,7 +151,7 @@ namespace MaterialDesignThemes.Wpf
 		}
 
 		public static readonly DependencyProperty ClockHostContentControlStyleProperty = DependencyProperty.Register(
-			"ClockHostContentControlStyle", typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
+            nameof(ClockHostContentControlStyle), typeof (Style), typeof (TimePicker), new PropertyMetadata(default(Style)));
 
 	    public Style ClockHostContentControlStyle
 		{

--- a/MaterialDesignThemes.Wpf/Underline.cs
+++ b/MaterialDesignThemes.Wpf/Underline.cs
@@ -25,7 +25,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register(
-            "IsActive", typeof(bool), typeof(Underline),
+            nameof(IsActive), typeof(bool), typeof(Underline),
             new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.AffectsRender, IsActivePropertyChangedCallback));
 
         private static void IsActivePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)

--- a/paket-files/ControlzEx/ControlzEx/src/ControlzEx/PackIconBase.cs
+++ b/paket-files/ControlzEx/ControlzEx/src/ControlzEx/PackIconBase.cs
@@ -31,7 +31,7 @@ namespace ControlzEx
         }
 
         public static readonly DependencyProperty KindProperty = DependencyProperty.Register(
-            "Kind", typeof(TKind), typeof(PackIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
+            nameof(Kind), typeof(TKind), typeof(PackIconBase<TKind>), new PropertyMetadata(default(TKind), KindPropertyChangedCallback));
 
         private static void KindPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
         {

--- a/paket-files/ControlzEx/ControlzEx/src/ControlzEx/PopupEx.cs
+++ b/paket-files/ControlzEx/ControlzEx/src/ControlzEx/PopupEx.cs
@@ -20,7 +20,7 @@ namespace ControlzEx
     public class PopupEx : Popup
     {
         public static readonly DependencyProperty CloseOnMouseLeftButtonDownProperty
-            = DependencyProperty.Register("CloseOnMouseLeftButtonDown",
+            = DependencyProperty.Register(nameof(CloseOnMouseLeftButtonDown),
                                           typeof(bool),
                                           typeof(PopupEx),
                                           new PropertyMetadata(false));

--- a/paket-files/samueldjack/VirtualCollection/VirtualCollection/VirtualCollection/VirtualizingWrapPanel.cs
+++ b/paket-files/samueldjack/VirtualCollection/VirtualCollection/VirtualCollection/VirtualizingWrapPanel.cs
@@ -20,10 +20,10 @@ namespace VirtualCollection.VirtualCollection
         private readonly Dictionary<UIElement, Rect> _childLayouts = new Dictionary<UIElement, Rect>();
 
         public static readonly DependencyProperty ItemWidthProperty =
-            DependencyProperty.Register("ItemWidth", typeof(double), typeof(VirtualizingWrapPanel), new PropertyMetadata(1.0, HandleItemDimensionChanged));
+            DependencyProperty.Register(nameof(ItemWidth), typeof(double), typeof(VirtualizingWrapPanel), new PropertyMetadata(1.0, HandleItemDimensionChanged));
 
         public static readonly DependencyProperty ItemHeightProperty =
-            DependencyProperty.Register("ItemHeight", typeof(double), typeof(VirtualizingWrapPanel), new PropertyMetadata(1.0, HandleItemDimensionChanged));
+            DependencyProperty.Register(nameof(ItemHeight), typeof(double), typeof(VirtualizingWrapPanel), new PropertyMetadata(1.0, HandleItemDimensionChanged));
 
         private static readonly DependencyProperty VirtualItemIndexProperty =
             DependencyProperty.RegisterAttached("VirtualItemIndex", typeof(int), typeof(VirtualizingWrapPanel), new PropertyMetadata(-1));


### PR DESCRIPTION
This will require VS2015+, but nameof was already being used anyway.
Maintainability is improved because Intellisense does not work for names passed as string literals.