### PR TITLE
ArgumentNullException with C#6 nameof

### DIFF
--- a/MaterialDesignThemes.Wpf/DateTimeEx.cs
+++ b/MaterialDesignThemes.Wpf/DateTimeEx.cs
@@ -8,7 +8,7 @@ namespace MaterialDesignThemes.Wpf
 	{
 		internal static DateTimeFormatInfo GetDateFormat(this CultureInfo culture)
 		{
-			if (culture == null) throw new ArgumentNullException("culture");
+			if (culture == null) throw new ArgumentNullException(nameof(culture));
 
 			if (culture.Calendar is GregorianCalendar)
 			{


### PR DESCRIPTION
Replaces the only case of a string on argument of ArgumentNullException