### PR TITLE
Change the divider color to 12% opacity per-spec.  Fixes #287.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -17,8 +17,7 @@
     <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#FF647076" />
 	
 	<SolidColorBrush x:Key="MaterialDesignTextBoxBorder" Color="#89FFFFFF" />
-    
-    <SolidColorBrush x:Key="MaterialDesignDivider" Color="#616161" />
+    <SolidColorBrush x:Key="MaterialDesignDivider" Color="#1FFFFFFF" /><!-- 12% -->
     <SolidColorBrush x:Key="MaterialDesignSelection" Color="#757575" />
 
     <SolidColorBrush x:Key="MaterialDesignFlatButtonClick" Color="#757575" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -15,8 +15,7 @@
     <SolidColorBrush x:Key="MaterialDesignCheckBoxDisabled" Color="#FFBDBDBD" />
 
     <SolidColorBrush x:Key="MaterialDesignTextBoxBorder" Color="#89000000" />
-    
-    <SolidColorBrush x:Key="MaterialDesignDivider" Color="#FFB6B6B6" />
+    <SolidColorBrush x:Key="MaterialDesignDivider" Color="#1F000000" /> <!-- 12% -->
     <SolidColorBrush x:Key="MaterialDesignSelection" Color="#FFDeDeDe" />
 
     <SolidColorBrush x:Key="MaterialDesignFlatButtonClick" Color="#FFDeDeDe" />


### PR DESCRIPTION
Refrained from cleanup in case you wanted to park this until a larger milestone, since these constitute visual changes.

Dark:
Before:
![image](https://cloud.githubusercontent.com/assets/838256/13847499/839a76f4-ec1b-11e5-93ae-20553d492f61.png)

After:
![image](https://cloud.githubusercontent.com/assets/838256/13847504/896f6f62-ec1b-11e5-997e-84b795728f96.png)

Light:
Before:
![image](https://cloud.githubusercontent.com/assets/838256/13847509/90af33c0-ec1b-11e5-9bc2-c5ce16cdac9d.png)

After:
![image](https://cloud.githubusercontent.com/assets/838256/13847514/957f54c0-ec1b-11e5-9cd5-ff50557ddaf6.png)
