### PR TITLE
Add Default Consturctor to TransitionEffectExtension

### DIFF
--- a/MainDemo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
+++ b/MainDemo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
@@ -36,7 +36,7 @@
                     <Setter Property="Mode" Value="PrimaryLight" />
                 </Style>
             </ItemsControl.Resources>
-            <materialDesign:TransitioningContent OpeningEffect="{materialDesign:TransitionEffect ExpandIn}">
+            <materialDesign:TransitioningContent OpeningEffect="{materialDesign:TransitionEffect Kind=ExpandIn}">
                 <materialDesign:ColorZone>
                     <materialDesign:PackIcon Kind="Phone" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </materialDesign:ColorZone>

--- a/MainDemo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
+++ b/MainDemo.Wpf/TransitionsDemo/Slide5_TransitioningContent.xaml
@@ -36,7 +36,7 @@
                     <Setter Property="Mode" Value="PrimaryLight" />
                 </Style>
             </ItemsControl.Resources>
-            <materialDesign:TransitioningContent OpeningEffect="{materialDesign:TransitionEffect Kind=ExpandIn}">
+            <materialDesign:TransitioningContent OpeningEffect="{materialDesign:TransitionEffect ExpandIn}">
                 <materialDesign:ColorZone>
                     <materialDesign:PackIcon Kind="Phone" VerticalAlignment="Center" HorizontalAlignment="Center" />
                 </materialDesign:ColorZone>

--- a/MaterialDesignThemes.Wpf/Transitions/TransitionEffectExtension.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitionEffectExtension.cs
@@ -6,6 +6,11 @@ namespace MaterialDesignThemes.Wpf.Transitions
     [MarkupExtensionReturnType(typeof(TransitionEffectBase))]
     public class TransitionEffectExtension : MarkupExtension
     {
+        public TransitionEffectExtension()
+        {
+            Kind = TransitionEffectKind.None;
+        }
+
         public TransitionEffectExtension(TransitionEffectKind kind)
         {
             Kind = kind;


### PR DESCRIPTION
It helps us to get rid of these errors:
In design time
![example1](https://cloud.githubusercontent.com/assets/5460448/14000080/8df8f56e-f150-11e5-814b-632ad2fa4df2.png)
And in runtime
![example2](https://cloud.githubusercontent.com/assets/5460448/14000079/8df77856-f150-11e5-80fa-e27875bbbfa7.png)
