### PR TITLE
Fixes fix of MathConverter

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/MathConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/MathConverter.cs
@@ -22,13 +22,12 @@ namespace MaterialDesignThemes.Wpf.Converters
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            double value1, value2;
-            if (Double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out value1) 
-				&& Double.TryParse(parameter.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out value2))
+            try
             {
+                double value1 = System.Convert.ToDouble(value, CultureInfo.InvariantCulture);
+                double value2 = System.Convert.ToDouble(parameter, CultureInfo.InvariantCulture);
                 switch (Operation)
                 {
-                    default:
                     case MathOperation.Add:
                         return value1 + value2;
                     case MathOperation.Divide:
@@ -37,10 +36,14 @@ namespace MaterialDesignThemes.Wpf.Converters
                         return value1 * value2;
                     case MathOperation.Subtract:
                         return value1 - value2;
+                    default:
+                        return Binding.DoNothing;
                 }
             }
-
-            return Binding.DoNothing;
+            catch (FormatException)
+            {
+                return Binding.DoNothing;
+            }
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
Double.TryParse(value.ToString(), NumberStyles.Any, ... ) converts input string like "23.066" into the 23066 number, and i got this:
![blob](https://cloud.githubusercontent.com/assets/5460448/14365482/8b945fc6-fd16-11e5-85a0-2af75dccdf8e.png)

So i've changed Double.TryParse to Convert.ToDouble with try-catch, i hope it will works with german system.


