### PR TITLE
Fix Ripple can't reset in Popup control.

### DIFF
--- a/MaterialDesignThemes.Wpf/Ripple.cs
+++ b/MaterialDesignThemes.Wpf/Ripple.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -26,6 +27,8 @@ namespace MaterialDesignThemes.Wpf
 
             EventManager.RegisterClassHandler(typeof(Window), Mouse.PreviewMouseUpEvent, new MouseButtonEventHandler(MouseButtonEventHandler), true);
             EventManager.RegisterClassHandler(typeof (Window), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMouveEventHandler), true);
+            EventManager.RegisterClassHandler(typeof(Popup), Mouse.PreviewMouseUpEvent, new MouseButtonEventHandler(MouseButtonEventHandler), true);
+            EventManager.RegisterClassHandler(typeof(Popup), Mouse.MouseMoveEvent, new MouseEventHandler(MouseMouveEventHandler), true);
         }
 
         public Ripple()


### PR DESCRIPTION
Hi!
This PR is fixed a issue about `Ripple` control.
If you use `Ripple` in a `Popup` control, the state of `Ripple` will not reset after you make the mouse up.
Because the `Ripple` only register the mouse event of `Window`.