### PR TITLE
Fixes alignment of error message in validation template #343

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ValidationErrorTemplate.xaml
@@ -9,7 +9,8 @@
             <DataTemplate DataType="{x:Type ValidationError}">
                 <TextBlock Foreground="{DynamicResource ValidationErrorBrush}"
                                        FontSize="10"
-                                       MaxWidth="250"
+                                       MaxWidth="{Binding ElementName=Placeholder, Path=ActualWidth}"
+                                       HorizontalAlignment="Left"
                                        Margin="2"
                                        TextWrapping="Wrap"
                                        Text="{Binding ErrorContent}"


### PR DESCRIPTION
Initially I also had a change for the demo project that demonstrated that this works. But I left it out since it did not feel important for the overall purpose of the demo. 

Anyway, works on my machine. Perhaps @lobin-z0x50 can verify this?