### PR TITLE
Add PopupOpened/PopupClosed events to PopupBox

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -81,8 +81,8 @@
                                          PlacementMode="BottomAndAlignCentres"
                                          ToolTipService.Placement="Right"
                                          ToolTip="PopupBox, Style MaterialDesignMultiFloatingActionPopupBox"
-                                         PopupOpened="PopupBox_OnPopupOpened"
-                                         PopupClosed="PopupBox_OnPopupClosed">
+                                         OnPopupOpened="PopupBox_OnPopupOpened"
+                                         OnPopupClosed="PopupBox_OnPopupClosed">
                     <StackPanel>
                         <Button ToolTip="One">1</Button>
                         <Button ToolTip="Two">2</Button>

--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -80,7 +80,9 @@
                 <materialDesign:PopupBox Style="{StaticResource MaterialDesignMultiFloatingActionPopupBox}"
                                          PlacementMode="BottomAndAlignCentres"
                                          ToolTipService.Placement="Right"
-                                         ToolTip="PopupBox, Style MaterialDesignMultiFloatingActionPopupBox">
+                                         ToolTip="PopupBox, Style MaterialDesignMultiFloatingActionPopupBox"
+                                         PopupOpened="PopupBox_OnPopupOpened"
+                                         PopupClosed="PopupBox_OnPopupClosed">
                     <StackPanel>
                         <Button ToolTip="One">1</Button>
                         <Button ToolTip="Two">2</Button>

--- a/MainDemo.Wpf/Buttons.xaml.cs
+++ b/MainDemo.Wpf/Buttons.xaml.cs
@@ -39,5 +39,15 @@ namespace MaterialDesignColors.WpfExample
 	    {
             Console.WriteLine("Just checking we haven't suppressed the button.");
 		}
+
+        private void PopupBox_OnPopupOpened(object sender, RoutedEventArgs e)
+        {
+            Console.WriteLine("Just making sure the popup has opened.");
+        }
+
+        private void PopupBox_OnPopupClosed(object sender, RoutedEventArgs e)
+        {
+            Console.WriteLine("Just making sure the popup has closed.");
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -246,7 +246,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 var popupOpenedEventArgs = new RoutedEventArgs()
                 {
-                    RoutedEvent = PopupOpenedEvent,
+                    RoutedEvent = OnPopupOpenedEvent,
                     Source = popupBox
                 };
                 popupBox.RaiseEvent(popupOpenedEventArgs);
@@ -255,7 +255,7 @@ namespace MaterialDesignThemes.Wpf
             {
                 var popupClosedEventArgs = new RoutedEventArgs()
                 {
-                    RoutedEvent = PopupClosedEvent,
+                    RoutedEvent = OnPopupClosedEvent,
                     Source = popupBox
                 };
                 popupBox.RaiseEvent(popupClosedEventArgs);
@@ -279,9 +279,9 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Event corresponds to the popup opening
         /// </summary>
-        public static readonly RoutedEvent PopupOpenedEvent = 
+        public static readonly RoutedEvent OnPopupOpenedEvent = 
             EventManager.RegisterRoutedEvent(
-                "PopupOpened", 
+                "OnPopupOpened", 
                 RoutingStrategy.Bubble, 
                 typeof(RoutedEventHandler), 
                 typeof(PopupBox));
@@ -289,29 +289,29 @@ namespace MaterialDesignThemes.Wpf
         /// <summary>
         /// Event corresponds to the popup closing
         /// </summary>
-        public static readonly RoutedEvent PopupClosedEvent = 
+        public static readonly RoutedEvent OnPopupClosedEvent = 
             EventManager.RegisterRoutedEvent(
-                "PopupClosed", 
+                "OnPopupClosed", 
                 RoutingStrategy.Bubble, 
                 typeof(RoutedEventHandler), 
                 typeof(PopupBox));
 
         /// <summary>
-        /// Add / Remove PopupOpenedEvent handler 
+        /// Add / Remove OnPopupOpenedEvent handler 
         /// </summary>
-        public event RoutedEventHandler PopupOpened
+        public event RoutedEventHandler OnPopupOpened
         {
-            add { AddHandler(PopupOpenedEvent, value); }
-            remove { RemoveHandler(PopupOpenedEvent, value); }
+            add { AddHandler(OnPopupOpenedEvent, value); }
+            remove { RemoveHandler(OnPopupOpenedEvent, value); }
         }
 
         /// <summary>
-        /// Add / Remove PopupClosedEvent handler 
+        /// Add / Remove OnPopupClosedEvent handler 
         /// </summary>
-        public event RoutedEventHandler PopupClosed
+        public event RoutedEventHandler OnPopupClosed
         {
-            add { AddHandler(PopupClosedEvent, value); }
-            remove { RemoveHandler(PopupClosedEvent, value); }
+            add { AddHandler(OnPopupClosedEvent, value); }
+            remove { RemoveHandler(OnPopupClosedEvent, value); }
         }
 
 

--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -242,7 +242,24 @@ namespace MaterialDesignThemes.Wpf
                 else
                     Mouse.Capture(null);
             }
-
+            if (newValue)
+            {
+                var popupOpenedEventArgs = new RoutedEventArgs()
+                {
+                    RoutedEvent = PopupOpenedEvent,
+                    Source = popupBox
+                };
+                popupBox.RaiseEvent(popupOpenedEventArgs);
+            }
+            else
+            {
+                var popupClosedEventArgs = new RoutedEventArgs()
+                {
+                    RoutedEvent = PopupClosedEvent,
+                    Source = popupBox
+                };
+                popupBox.RaiseEvent(popupClosedEventArgs);
+            }
             
             popupBox.AnimateChildrenIn(!newValue);                 
             popupBox._popup?.RefreshPosition();
@@ -258,6 +275,45 @@ namespace MaterialDesignThemes.Wpf
             get { return (bool) GetValue(IsPopupOpenProperty); }
             set { SetValue(IsPopupOpenProperty, value); }
         }
+
+        /// <summary>
+        /// Event corresponds to the popup opening
+        /// </summary>
+        public static readonly RoutedEvent PopupOpenedEvent = 
+            EventManager.RegisterRoutedEvent(
+                "PopupOpened", 
+                RoutingStrategy.Bubble, 
+                typeof(RoutedEventHandler), 
+                typeof(PopupBox));
+
+        /// <summary>
+        /// Event corresponds to the popup closing
+        /// </summary>
+        public static readonly RoutedEvent PopupClosedEvent = 
+            EventManager.RegisterRoutedEvent(
+                "PopupClosed", 
+                RoutingStrategy.Bubble, 
+                typeof(RoutedEventHandler), 
+                typeof(PopupBox));
+
+        /// <summary>
+        /// Add / Remove PopupOpenedEvent handler 
+        /// </summary>
+        public event RoutedEventHandler PopupOpened
+        {
+            add { AddHandler(PopupOpenedEvent, value); }
+            remove { RemoveHandler(PopupOpenedEvent, value); }
+        }
+
+        /// <summary>
+        /// Add / Remove PopupClosedEvent handler 
+        /// </summary>
+        public event RoutedEventHandler PopupClosed
+        {
+            add { AddHandler(PopupClosedEvent, value); }
+            remove { RemoveHandler(PopupClosedEvent, value); }
+        }
+
 
         public static readonly DependencyProperty StaysOpenProperty = DependencyProperty.Register(
             nameof(StaysOpen), typeof (bool), typeof (PopupBox), new PropertyMetadata(default(bool)));


### PR DESCRIPTION
I noticed that PopupBox was missing this event, which appears on the WPF Popup control. It doesn't pass through any special information so it utilizes normal `RoutedEventArgs`, and uses `Bubbling` routing strategy. 