### PR TITLE
Set SelectedTime property to null when Text property is empty or null…

### DIFF
--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -227,9 +227,13 @@ namespace MaterialDesignThemes.Wpf
 
 		private void TextBoxOnLostFocus(object sender, RoutedEventArgs routedEventArgs)
 		{
-		    if (string.IsNullOrEmpty(_textBox?.Text)) return;
+		    if (string.IsNullOrEmpty(_textBox?.Text))
+            {
+                SetCurrentValue(SelectedTimeProperty, null);
+                return;
+            }
 
-		    DateTime time;
+            DateTime time;
 		    if (IsTimeValid(_textBox.Text, out time))
 		        SetCurrentValue(SelectedTimeProperty, time);
 
@@ -305,6 +309,10 @@ namespace MaterialDesignThemes.Wpf
 			{
 				ParseTime(_textBox.Text, t => SetCurrentValue(SelectedTimeProperty, t));			
 			}
+            else
+            {
+                SetCurrentValue(SelectedTimeProperty, null);
+            }
 		}
 
 		private void ParseTime(string s, Action<DateTime> successContinuation)


### PR DESCRIPTION
…. Fixes #344

The indentation looked wierd on GitHub. Seems like you're using tabs and not spaces for indentation in `TimePicker.cs`. I've not seen this in other files.

