### PR TITLE
Expander

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -105,7 +105,7 @@
     </Style>
 
     <Style x:Key="MaterialDesignExpander" TargetType="{x:Type Expander}">
-        <Setter Property="Background" Value="{StaticResource MaterialDesignPaper}" />
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -179,7 +179,7 @@
                                 <ToggleButton Grid.Column="1"
                                               IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
                                               Style="{StaticResource MaterialDesignExpanderHeaderToggleButton}">
-                                    <ContentPresenter ContentSource="Header" HorizontalAlignment="Stretch" RecognizesAccessKey="True" VerticalAlignment="Center" />
+                                    <ContentPresenter ContentSource="Header" HorizontalAlignment="Stretch" RecognizesAccessKey="True" VerticalAlignment="Top" />
                                 </ToggleButton>
                             </Grid>
                         </Border>


### PR DESCRIPTION
Gifs, instead of a thousand words.

Before:
![expanderbefore](https://cloud.githubusercontent.com/assets/5460448/14871067/a2868b60-0ce7-11e6-94ad-c09e69ab6f62.gif)
After:
![expanderafter](https://cloud.githubusercontent.com/assets/5460448/14871075/a6f08674-0ce7-11e6-9813-63432028d9a3.gif)
