### PR TITLE
PopupBox mouse capture fix

### DIFF
--- a/MaterialDesignThemes.Wpf/PopupBox.cs
+++ b/MaterialDesignThemes.Wpf/PopupBox.cs
@@ -657,7 +657,7 @@ namespace MaterialDesignThemes.Wpf
                 }
                 else
                 {
-                    if (popupBox.StaysOpen)
+                    if (popupBox.StaysOpen && popupBox.IsPopupOpen)
                     {
                         // Take capture back because click happend outside of control
                         Mouse.Capture(popupBox, CaptureMode.SubTree);


### PR DESCRIPTION
Bug reproducible with the demo. Go on buttons tab. Click on the three dots (options) click on it again. Then you can't click on anything anymore.