### PR TITLE
Defaults KeyboardNavigation.IsTabStop of TransitioningContent to "False"

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -851,8 +851,8 @@
     </Style>
 
     <Style TargetType="{x:Type transitions:TransitioningContentBase}">
-		<Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
-		<Setter Property="Template">
+        <Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
+        <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type transitions:TransitioningContentBase}">
                     <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -851,8 +851,8 @@
     </Style>
 
     <Style TargetType="{x:Type transitions:TransitioningContentBase}">
-        
-        <Setter Property="Template">
+		<Setter Property="KeyboardNavigation.IsTabStop" Value="False"/>
+		<Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type transitions:TransitioningContentBase}">
                     <Border Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"

--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 
@@ -52,6 +53,8 @@ namespace MaterialDesignThemes.Wpf.Transitions
                 RegisterName(SkewTransformPartName, _skewTransform);
             if (_translateTransform != null)
                 RegisterName(TranslateTransformPartName, _translateTransform);
+
+			KeyboardNavigation.SetIsTabStop(this, false);
 
             base.OnApplyTemplate();
         }

--- a/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/TransitioningContentBase.cs
@@ -4,7 +4,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 
@@ -53,8 +52,6 @@ namespace MaterialDesignThemes.Wpf.Transitions
                 RegisterName(SkewTransformPartName, _skewTransform);
             if (_translateTransform != null)
                 RegisterName(TranslateTransformPartName, _translateTransform);
-
-			KeyboardNavigation.SetIsTabStop(this, false);
 
             base.OnApplyTemplate();
         }


### PR DESCRIPTION
Sets KeyboardNavigation.IsTabStop to false in OnApplyTemplate().

Transitioning content was getting keyboard focus via tab key on its content area.