### PR TITLE
Changed MaterialDesignCheckBox default VerticalContentAlignment to "Center" 

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -47,6 +47,7 @@
     <Style x:Key="MaterialDesignCheckBox" TargetType="{x:Type CheckBox}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -47,7 +47,6 @@
     <Style x:Key="MaterialDesignCheckBox" TargetType="{x:Type CheckBox}">
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="BorderThickness" Value="1"/>
-        <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>


### PR DESCRIPTION
This makes it look aligned with any font size
![image](https://cloud.githubusercontent.com/assets/16761301/16121702/4424f1b4-33b2-11e6-9c78-4faf517a0878.png)
