### PR TITLE
ComboBoxHintProxy.Content dependent on ComboBox.IsEditable

### DIFF
--- a/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
+++ b/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
@@ -16,7 +16,10 @@ namespace MaterialDesignThemes.Wpf
             private readonly ComboBox _comboBox;
             private readonly TextChangedEventHandler _comboBoxTextChangedEventHandler;
 
-            public object Content => _comboBox.Text;
+            public object Content => _comboBox.IsEditable 
+                ? _comboBox.Text 
+                : _comboBox.SelectedItem != null ? " " : null;
+
             public bool IsLoaded => _comboBox.IsLoaded;
             public bool IsVisible => _comboBox.IsVisible;
 


### PR DESCRIPTION
Investigating this trigger I kept thinking that the control was not picking up focus properly:
```xaml
<MultiTrigger>
    <MultiTrigger.Conditions>
        <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
        <Condition Property="IsKeyboardFocused" Value="True" />
    </MultiTrigger.Conditions>
    <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
    <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
</MultiTrigger>
```

In reality, the ```<Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />``` was not firing, at least not until the ComboBox's selection was changed once.  [Apparently](http://stackoverflow.com/questions/21552789/combobox-text-vs-combobox-selecteditem-vs-combobox-selectvalue#answer-21552919) ```ComboBox.Text``` property in non-editable ComboBoxes slacks one state behind from its current selection, and ```ComboBoxHintProxy``` was using that Text property to determine whether the ComboBox has content, which affects ```SmartHint.IsContentNullOrEmpty```. So, starting from an empty selection, it would take two selection changes to affect IsContentNullOrEmpty, which would prevent the hint from getting focus color right away.

To overcome this I propose ```ComboBoxHintProxy.Content``` to treat non editable comboboxes differently. If ```ComboBox.SelectedItem``` is not null, it should indicate that the combobox has content, which in turn determines IsContentNullOrEmpty without delay.

In this line ```_comboBox.SelectedItem != null ? " " : null``` I could have returned the SelectedItem directly, but this check takes into consideration the case of an empty string (or any object whose ToString returns string.Empty) in the combo's item source. If there would be an empty string in the list, and having it selected, its ```ToString()``` would fulfill ```IsContentNullOrEmpty```, and would cause the hint to show despite having an item selected, creating the false illusion that the combobox has no selection. As the combobox is non-editable, it would make sense to make it clear that the user has selected an item, whatever it's textual value may be.