### PR TITLE
TimePicker SelectedTime setting value to null fix

### DIFF
--- a/MainDemo.Wpf/Pickers.xaml
+++ b/MainDemo.Wpf/Pickers.xaml
@@ -45,10 +45,15 @@
             <DatePicker Name="LocaleDatePicker" Width="120" HorizontalAlignment="Left" Margin="0 16 0 0" materialDesign:HintAssist.Hint="Locale Date" />
             <DatePicker Name="LocaleDatePickerRTL" Width="120" HorizontalAlignment="Left" Margin="0 16 0 0" materialDesign:HintAssist.Hint="RTL Locale Date" FlowDirection="RightToLeft" />
         </StackPanel>
-        <materialDesign:TimePicker Grid.Row="1" Grid.Column="1"  VerticalAlignment="Top"  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0"
+            <StackPanel Grid.Row="1" Grid.Column="1"  VerticalAlignment="Top">
+            <materialDesign:TimePicker  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0"
                                    Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
                                    materialDesign:HintAssist.Hint="Custom hint" />
-        <materialDesign:TimePicker Grid.Row="1" Grid.Column="2"  Is24Hours="True" x:Name="PresetTimePicker" VerticalAlignment="Top"  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0" />
+             <materialDesign:TimePicker SelectedTime="{Binding BindingDateTime}" Width="100" HorizontalAlignment="Left" Margin="0 26 0 0"
+                                   Style="{StaticResource MaterialDesignFloatingHintTimePicker}"
+                                   materialDesign:HintAssist.Hint="SelectedTime Binding" />
+            </StackPanel>
+            <materialDesign:TimePicker Grid.Row="1" Grid.Column="2"  Is24Hours="True" x:Name="PresetTimePicker" VerticalAlignment="Top"  Width="100" HorizontalAlignment="Left" Margin="0 16 0 0" />
         <materialDesign:TimePicker Grid.Row="1" Grid.Column="3"                
                                    materialDesign:HintAssist.Hint="Validates"
                                    IsInvalidTextAllowed="True"

--- a/MainDemo.Wpf/PickersViewModel.cs
+++ b/MainDemo.Wpf/PickersViewModel.cs
@@ -12,6 +12,7 @@ namespace MaterialDesignColors.WpfExample
     {
         private DateTime _date;
         private DateTime _time;
+        private DateTime? _bindingDateTime;
         private string _validatingTime;
         private DateTime? _futureValidatingDate;
 
@@ -19,6 +20,7 @@ namespace MaterialDesignColors.WpfExample
         {
             Date = DateTime.Now;
             Time = DateTime.Now;
+            BindingDateTime = DateTime.Now;
         }
 
         public DateTime Date
@@ -61,6 +63,15 @@ namespace MaterialDesignColors.WpfExample
             }
         }
 
+        public DateTime? BindingDateTime
+        {
+            get { return _bindingDateTime; }
+            set
+            {
+                _bindingDateTime = value;
+                OnPropertyChanged();
+            }
+        }
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -51,9 +51,11 @@ namespace MaterialDesignThemes.Wpf
 		private static void TextPropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
 			var timePicker = (TimePicker) dependencyObject;
-			timePicker.SetSelectedTime();
-			if (timePicker._textBox != null)
-				timePicker._textBox.Text = dependencyPropertyChangedEventArgs.NewValue as string;
+		    if (timePicker._textBox != null)
+		    {
+                timePicker.SetSelectedTime();
+                timePicker._textBox.Text = dependencyPropertyChangedEventArgs.NewValue as string;
+		    }
 		}
 
 		public string Text


### PR DESCRIPTION
I observed and was able to identify that the **SelectedTime** property on **TimePicker** will fail to display the initial value of a property that is bound to it. Upon initial load of the control WPF will set up the bindings before **OnApplyTemplate** is called. So while the control is being created the bindings for **SelectedTime** are applied. This kicks off a call **SelectedTimePropertyChangedCallback** with the value evaluated from the bindings. This in turn makes a call to change the **TextProperty** value. When **TextProperty** changes it calls **SetSelectedTime()**. **SetSelectedTime()** will in then change the SelectedTime property based on the **Text** of the **_textBox** that is retrieved from the control template. Since this does not yet exist it evaluates to empty. Since it evaluates to empty **SelectedTime** is set to **null**. Which kicks this chain off again. The end result being the **SeletedTime** value and the **TextProperty** value are now null and the _textBox.Text value ends up being null. Thus not displaying the time to the user.

This fix is to only call **SetSelectedTime()** from within the **TextPropertyChangedCallback** if the **_textBox** control is not null. This callback already had this code in there for updating the .Text property of the **_textBox**. 

An alternative possible fix would be to update **SetSelectedTime()** to do an additional check to see if **_textBox** control is not null and only set **SelectedTime** if the control exists.

This PR also includes an example of the binding working in the demo project.