### PR TITLE
Explicit styling of PoupBox used as a Window Command in MahApps

### DIFF
--- a/MahMaterialDragablzMashUp/MainWindow.xaml
+++ b/MahMaterialDragablzMashUp/MainWindow.xaml
@@ -5,6 +5,7 @@
                       xmlns:dragablz="clr-namespace:Dragablz;assembly=Dragablz"
                       xmlns:mahMaterialDragablzMashUp="clr-namespace:MahMaterialDragablzMashUp"
                       xmlns:dockablz="clr-namespace:Dragablz.Dockablz;assembly=Dragablz"
+                      xmlns:wpf="http://materialdesigninxaml.net/winfx/xaml/themes"
                       WindowTransitionsEnabled="False"
                       TextElement.Foreground="{DynamicResource MaterialDesignBody}"
                       Background="{DynamicResource MaterialDesignPaper}"					  
@@ -18,7 +19,18 @@
             </controls:Flyout>
         </controls:FlyoutsControl>
     </controls:MetroWindow.Flyouts>
-    <dockablz:Layout>
+    <controls:MetroWindow.LeftWindowCommands>
+        <controls:WindowCommands>
+            <wpf:PopupBox Style="{StaticResource WindowCommandsPopupBoxStyle}">
+                <StackPanel>
+                    <Button Content="Hello World"/>
+                    <Button Content="Nice Popup"/>
+                    <Button Content="Goodbye"/>
+                </StackPanel>
+            </wpf:PopupBox>
+        </controls:WindowCommands>
+    </controls:MetroWindow.LeftWindowCommands>
+        <dockablz:Layout>
         <dragablz:TabablzControl BorderThickness="0"
                                  Margin="0,-1,0,1">
             <dragablz:TabablzControl.InterTabController>

--- a/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
+++ b/MaterialDesignThemes.MahApps/MaterialDesignThemes.MahApps.csproj
@@ -79,6 +79,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Themes\MaterialDesignTheme.MahApps.WindowCommands.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FlyoutAssist.cs" />

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.Defaults.xaml
@@ -6,6 +6,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.RangeSlider.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.WindowCommands.xaml" />
     </ResourceDictionary.MergedDictionaries>
     
     <Style TargetType="{x:Type controls:RangeSlider}" BasedOn="{StaticResource MaterialDesignRangeSlider}" />

--- a/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.WindowCommands.xaml
+++ b/MaterialDesignThemes.MahApps/Themes/MaterialDesignTheme.MahApps.WindowCommands.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="http://materialdesigninxaml.net/winfx/xaml/themes"
+                    xmlns:controls="http://metro.mahapps.com/winfx/xaml/controls">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.PopupBox.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+    <Style x:Key="WindowCommandsPopupBoxStyle" TargetType="{x:Type wpf:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}">
+        <Setter Property="Opacity" Value="0.5"/>
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Opacity" Value="1" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
Explicit style for material design `PopupBox` when used in MahApps `MetroWindow` `LeftWindowCommands` and `RightWindowCommands`

Basically makes  the PopupBox look the same (opacity 50%) as other buttons. 

Would be nice if the PR could be improved to style the PopupBox implicitly when used as a window command, just as with buttons that do not need the explicit style.

![animation](https://cloud.githubusercontent.com/assets/1139118/16445280/5261006c-3de2-11e6-8474-48c301de2696.gif)
