### PR TITLE
Implicit styling of <Separator/> when used in a PopupBox

### DIFF
--- a/MainDemo.Wpf/MainWindow.xaml
+++ b/MainDemo.Wpf/MainWindow.xaml
@@ -195,7 +195,9 @@
                         <materialDesign:PopupBox DockPanel.Dock="Right" PlacementMode="BottomAndAlignRightEdges" StaysOpen="False">
                             <StackPanel>
                                 <Button Content="Hello World" Click="MenuPopupButton_OnClick"/>
+                                <Separator/>
                                 <Button Content="Nice Popup" Click="MenuPopupButton_OnClick"/>
+                                <Separator/>
                                 <Button Content="Goodbye" Click="MenuPopupButton_OnClick"/>                                
                             </StackPanel>
                         </materialDesign:PopupBox>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -6,6 +6,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Button.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Menu.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToolTip.xaml" />
     </ResourceDictionary.MergedDictionaries>
         
@@ -28,6 +29,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
                     <ControlTemplate.Resources>
+                        <Style TargetType="Separator" BasedOn="{StaticResource MaterialDesignSeparator}"/>
                         <Style TargetType="ToggleButton" x:Key="ToggleButtonStyle">
                             <Setter Property="Template">
                                 <Setter.Value>


### PR DESCRIPTION
### XAML

```
<materialDesign:PopupBox DockPanel.Dock="Right" PlacementMode="BottomAndAlignRightEdges" StaysOpen="False">
    <StackPanel>
        <Button Content="Hello World" Click="MenuPopupButton_OnClick"/>
        <Separator/>
        <Button Content="Nice Popup" Click="MenuPopupButton_OnClick"/>
        <Separator/>
        <Button Content="Goodbye" Click="MenuPopupButton_OnClick"/>                                
    </StackPanel>
</materialDesign:PopupBox>
```

### Runtime
![animation](https://cloud.githubusercontent.com/assets/1139118/16483544/26c3f6f2-3eb5-11e6-92df-e5dc0619a994.gif)
