### PR TITLE
Fix DoubleAnimation designer exception

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -233,10 +233,7 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Content" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content"
-                                                             To="1" Duration="0:0:0.3"/>
-                                            <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ContentPanel"
-                                                             To="1" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content" To="1" Duration="0:0:0.3"/>
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition GeneratedDuration="0" To="Collapsed">
@@ -247,17 +244,13 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Content" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content"
-                                                             To="0" Duration="0:0:0.3"/>
-                                            <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ContentPanel"
-                                                             To="0" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content" To="0" Duration="0:0:0.3"/>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Expanded">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content" To="1" Duration="0"/>
-                                        <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ContentPanel" To="1" Duration="0"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Content" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -266,7 +259,6 @@
                                 <VisualState x:Name="Collapsed">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="PART_Content" To="0" Duration="0"/>
-                                        <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ContentPanel" To="0" Duration="0"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PART_Content" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Hidden}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -291,19 +283,16 @@
                                     DockPanel.Dock="Bottom">
                                 <StackPanel Name="ContentPanel"
                                             HorizontalAlignment="Left">
-                                    <StackPanel.Tag>
-                                        <system:Double>0.0</system:Double>
-                                    </StackPanel.Tag>
                                     <StackPanel.Height>
                                         <MultiBinding Converter="{StaticResource MathMlpMultipleConverter}">
                                             <Binding ElementName="PART_Content" Path="ActualHeight"/>
-                                            <Binding RelativeSource="{RelativeSource Self}" Path="Tag"/>
+                                            <Binding ElementName="PART_Content" Path="Opacity"/>
                                         </MultiBinding>
                                     </StackPanel.Height>
                                     <StackPanel.Width>
                                         <MultiBinding Converter="{StaticResource MathMlpMultipleConverter}">
                                             <Binding ElementName="PART_Content" Path="ActualWidth"/>
-                                            <Binding RelativeSource="{RelativeSource Self}" Path="Tag"/>
+                                            <Binding ElementName="PART_Content" Path="Opacity"/>
                                         </MultiBinding>
                                     </StackPanel.Width>
                                     <ContentPresenter Name="PART_Content" Focusable="False"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TreeView.xaml
@@ -214,10 +214,7 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ItemsHost" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost"
-                                                             To="1" Duration="0:0:0.3"/>
-                                            <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ItemsPanel"
-                                                             To="1" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost" To="1" Duration="0:0:0.3"/>
                                         </Storyboard>
                                     </VisualTransition>
                                     <VisualTransition GeneratedDuration="0" To="Collapsed">
@@ -228,19 +225,13 @@
                                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ItemsHost" Storyboard.TargetProperty="Visibility">
                                                 <DiscreteObjectKeyFrame KeyTime="0:0:0.3" Value="{x:Static Visibility.Collapsed}" />
                                             </ObjectAnimationUsingKeyFrames>
-                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost"
-                                                             To="0" Duration="0:0:0.3"/>
-                                            <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ItemsPanel"
-                                                             To="0" Duration="0:0:0.3"/>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost" To="0" Duration="0:0:0.3"/>
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Expanded">
                                     <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost"
-                                                             To="1" Duration="0"/>
-                                        <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ItemsPanel"
-                                                             To="1" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost" To="1" Duration="0"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ItemsHost" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Visible}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -248,10 +239,7 @@
                                 </VisualState>
                                 <VisualState x:Name="Collapsed">
                                     <Storyboard>
-                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost"
-                                                             To="0" Duration="0"/>
-                                        <DoubleAnimation Storyboard.TargetProperty="Tag" Storyboard.TargetName="ItemsPanel"
-                                                             To="0" Duration="0"/>
+                                        <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="ItemsHost" To="0" Duration="0"/>
                                         <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ItemsHost" Storyboard.TargetProperty="Visibility">
                                             <DiscreteObjectKeyFrame KeyTime="0" Value="{x:Static Visibility.Collapsed}" />
                                         </ObjectAnimationUsingKeyFrames>
@@ -294,13 +282,10 @@
                                     x:Name="ItemsPanel"
                                     Margin="-16 0 0 0"
                                     Grid.ColumnSpan="2">
-                            <StackPanel.Tag>
-                                <system:Double>0.0</system:Double>
-                            </StackPanel.Tag>
                             <StackPanel.Height>
                                 <MultiBinding Converter="{StaticResource MathMlpMultipleConverter}">
                                     <Binding ElementName="ItemsHost" Path="ActualHeight"/>
-                                    <Binding RelativeSource="{RelativeSource Self}" Path="Tag"/>
+                                    <Binding ElementName="ItemsHost" Path="Opacity"/>
                                 </MultiBinding>
                             </StackPanel.Height>
                             <ItemsPresenter x:Name="ItemsHost"


### PR DESCRIPTION
Animate the Tag property with a double causes this exception at the VS designer

```
InvalidCastException: Specified cast is not valid.
Stacktrace
at System.Windows.Media.Animation.DoubleAnimationBase.GetCurrentValue(Object defaultOriginValue, Object defaultDestinationValue, AnimationClock animationClock)
   at System.Windows.Media.Animation.AnimationStorage.GetCurrentPropertyValue(AnimationStorage storage, DependencyObject d, DependencyProperty dp, PropertyMetadata metadata, Object baseValue)
   at System.Windows.Media.Animation.AnimationStorage.OnCurrentTimeInvalidated(Object sender, EventArgs args)
InnerException: None
```

To avoid this, we can use the Opacity property here too, cause it animates the same double value as for the Tag property (tricky).

Closes #485 Can't view various demo .xaml files in designer due to exceptions