### PR TITLE
Changed dark theme background to match guidelines

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -35,7 +35,7 @@
     </ControlTemplate>
     <Style TargetType="{x:Type wpf:Card}">
         <Setter Property="Template" Value="{StaticResource CardTemplate}" />
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth2" />
     </Style>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -6,7 +6,8 @@
     <SolidColorBrush x:Key="ValidationErrorBrush" Color="{StaticResource ValidationErrorColor}"/>
 
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FF000000" po:Freeze="True" />
-    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FF37474f" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FF303030" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FF424242" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DDFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#89FFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignColumnHeader" Color="#BCFFFFFF" po:Freeze="True" /><!-- 74% -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Defaults.xaml
@@ -38,7 +38,7 @@
     </ResourceDictionary.MergedDictionaries>
     <SolidColorBrush x:Key="MaterialDesignLightBackground" Color="#FFFAFAFA"/>
     <SolidColorBrush x:Key="MaterialDesignLightForeground" Color="#DD000000"/>
-    <SolidColorBrush x:Key="MaterialDesignDarkBackground" Color="#FF37474f"/>
+    <SolidColorBrush x:Key="MaterialDesignDarkBackground" Color="#FF303030"/>
     <SolidColorBrush x:Key="MaterialDesignDarkForeground" Color="#FFFAFAFA"/>
     <SolidColorBrush x:Key="MaterialDesignDarkSeparatorBackground" Color="#1F000000" />
     <SolidColorBrush x:Key="MaterialDesignLightSeparatorBackground" Color="#1FFFFFFF" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -7,6 +7,7 @@
 
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FFFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FFfafafa" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FFFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DD000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#89000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignColumnHeader" Color="#BC000000" po:Freeze="True" /> <!-- 74% -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -7,7 +7,7 @@
 
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FFFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FFfafafa" po:Freeze="True" />
-    <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FFFFFFFF" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FFfafafa" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DD000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#89000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignColumnHeader" Color="#BC000000" po:Freeze="True" /> <!-- 74% -->


### PR DESCRIPTION
Changed `MaterialDesignPaper` color resource to match the recommended value specified in https://material.google.com/style/color.html#color-themes

`MaterialDesignDarkBackground` has also been changed to #FF303030

Because cards are defined to have a different color than the background, a new resource named `MaterialDesignCardBackground` has been added. Card template now uses this resource for its background.

The guideline says that light theme cards should have a #FFFFFF value, but that needs to be discussed so I didn't set that yet.

We shouldn't merge these changes without first considering its effect on existing controls.

ComboBoxes, Calendars, TimePickers and some other popups would likely need to use the new card background color.
