### PR TITLE
Reverted ComboBoxHintProxy empty string behavior

### DIFF
--- a/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
+++ b/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
@@ -16,9 +16,21 @@ namespace MaterialDesignThemes.Wpf
             private readonly ComboBox _comboBox;
             private readonly TextChangedEventHandler _comboBoxTextChangedEventHandler;
 
-            public object Content => _comboBox.IsEditable 
-                ? _comboBox.Text 
-                : _comboBox.SelectedItem != null ? " " : null;
+            public object Content
+            {
+                get
+                {
+                    if (_comboBox.IsEditable)
+                    {
+                        return _comboBox.Text;
+                    }
+
+                    ComboBoxItem comboBoxItem = _comboBox.SelectedItem as ComboBoxItem;
+                    return comboBoxItem != null 
+                        ? comboBoxItem.Content
+                        : _comboBox.SelectedItem;
+                }
+            }
 
             public bool IsLoaded => _comboBox.IsLoaded;
             public bool IsVisible => _comboBox.IsVisible;


### PR DESCRIPTION
Reverted changes made in #417 regarding empty values on non-editable ComboBoxes. Extra checks had to be taken to prevent reintroducing the bug for which the original PR had been raised.