### PR TITLE
MaterialDesignCardBackground for ComboBox popups

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -473,9 +473,6 @@
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="templateRoot" Property="Opacity" Value="0.56"/>
             </Trigger>
-            <Trigger Property="IsDropDownOpen" Value="True">
-                <Setter TargetName="templateRoot" Property="Background" Value="{DynamicResource MaterialDesignCardBackground}"/>
-            </Trigger>
             <Trigger Property="IsEditable" Value="True">
                 <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
                 <Setter TargetName="Underline" Property="Visibility" Value="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -473,6 +473,9 @@
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="templateRoot" Property="Opacity" Value="0.56"/>
             </Trigger>
+            <Trigger Property="IsDropDownOpen" Value="True">
+                <Setter TargetName="templateRoot" Property="Background" Value="{DynamicResource MaterialDesignCardBackground}"/>
+            </Trigger>
             <Trigger Property="IsEditable" Value="True">
                 <Setter TargetName="PART_EditableTextBox" Property="Visibility" Value="Visible" />
                 <Setter TargetName="Underline" Property="Visibility" Value="{Binding Path=(wpf:TextFieldAssist.DecorationVisibility), RelativeSource={RelativeSource TemplatedParent}}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -591,4 +591,24 @@
         <Setter Property="wpf:HintAssist.IsFloating" Value="True"/>
     </Style>
 
+    <Style x:Key="MaterialDesignCardColorComboBox"
+           BasedOn="{StaticResource MaterialDesignComboBox}"
+           TargetType="{x:Type ComboBox}">
+        <Style.Triggers>
+            <Trigger Property="IsDropDownOpen" Value="True">
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+    <Style x:Key="MaterialDesignFloatingHintCardColorComboBox"
+           BasedOn="{StaticResource MaterialDesignFloatingHintComboBox}"
+           TargetType="{x:Type ComboBox}">
+        <Style.Triggers>
+            <Trigger Property="IsDropDownOpen" Value="True">
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignCardBackground}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
 </ResourceDictionary>


### PR DESCRIPTION
Added a trigger to set combobox background to MaterialDesignCardBackground when IsDropDownOpen.

![comboboxpopup](https://cloud.githubusercontent.com/assets/12145268/19990162/e10b2e16-a22b-11e6-9cc5-3594db23ed83.png)

The spec doesn't explicitly specify a color for combobox popups and even google has inconsistencies. In some cases I found a 250 popup and in others a 255. But considering that the idea of material design is utilizing the Z-layer for attention direction, popups, cards, dialogs and other things that are higher in Z usually have lighter color. This effect is clearly noticeable in the dark theme.

This is more based on preference so I advise not to merge without further consideration and research. Also note the 1px bug at the right side... I will look into what's causing it. 

An animation matching the popup fade would also be better than the instant color change.

![combobox](https://cloud.githubusercontent.com/assets/12145268/19989181/14f3a372-a225-11e6-9ce0-74baf2779215.png)

If we start this route we need to fix calendars, time pickers and some other controls too.

![calendar](https://cloud.githubusercontent.com/assets/12145268/19990498/71ad058c-a22e-11e6-9afe-e674184f548a.png)
