### PR TITLE
Changes to ToolBar to make it closer to MD

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -302,49 +302,6 @@
                     <materialDesign:PackIcon Kind="FormatAlignJustify"/>
                 </ListBoxItem>
             </ListBox>
-
-            <ListBox Grid.Column="1" Grid.Row="1" Style="{StaticResource MaterialDesignToolToggleFlatListBox}" SelectedIndex="0">
-                <ListBox.ToolTip>
-                    <StackPanel>
-                        <TextBlock Text="MaterialDesignToolToggleFlatListBox" />
-                        <TextBlock Text="Exclusive selection" />
-                        <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
-                    </StackPanel>
-                </ListBox.ToolTip>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatAlignLeft"/>
-                </ListBoxItem>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatAlignCenter"/>
-                </ListBoxItem>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatAlignRight"/>
-                </ListBoxItem>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatAlignJustify"/>
-                </ListBoxItem>
-            </ListBox>
-            
-            <ListBox Grid.Column="1" Grid.Row="2" Style="{StaticResource MaterialDesignToolToggleListBox}" 
-                 SelectionMode="Extended"
-                 Margin="0 8 0 0">
-                <ListBox.ToolTip>
-                    <StackPanel>
-                        <TextBlock Text="MaterialDesignToolToggleListBox" />
-                        <TextBlock Text="Multiple selection" />
-                        <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
-                    </StackPanel>
-                </ListBox.ToolTip>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatBold"/>
-                </ListBoxItem>
-                <ListBoxItem>
-                    <materialDesign:PackIcon Kind="FormatItalic"/>
-                </ListBoxItem>
-                <ListBoxItem x:Name="UnderlineCheckbox">
-                    <materialDesign:PackIcon Kind="FormatUnderline"/>
-                </ListBoxItem>
-            </ListBox>
         </Grid>
 
         <Border Grid.Row="6" Margin="0 16 0 0" BorderThickness="0 1 0 0" BorderBrush="{DynamicResource MaterialDesignDivider}" />

--- a/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -69,7 +69,32 @@
                 <Button Command="Paste" ToolTip="Paste some stuff" ToolBar.OverflowMode="AsNeeded">
                     <materialDesign:PackIcon Kind="ContentPaste" />
                 </Button>
-                <Separator />
+                <Separator/>
+                <ListBox Style="{StaticResource MaterialDesignToolToggleFlatListBox}">
+                    <ListBoxItem ToolTip="This is a lonley toggle with TextBlock instead of icon">
+                        <TextBlock>W</TextBlock>
+                    </ListBoxItem>
+                </ListBox>
+                <Separator/>
+                <ListBox SelectionMode="Extended" Style="{StaticResource MaterialDesignToolToggleFlatListBox}">
+                    <ListBox.ToolTip>
+                        <StackPanel>
+                            <TextBlock Text="MaterialDesignToolToggleListBox" />
+                            <TextBlock Text="Multiple selection" />
+                            <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
+                        </StackPanel>
+                    </ListBox.ToolTip>
+                    <ListBoxItem>
+                        <materialDesign:PackIcon Kind="FormatBold"/>
+                    </ListBoxItem>
+                    <ListBoxItem>
+                        <materialDesign:PackIcon Kind="FormatItalic"/>
+                    </ListBoxItem>
+                    <ListBoxItem x:Name="UnderlineCheckbox">
+                        <materialDesign:PackIcon Kind="FormatUnderline"/>
+                    </ListBoxItem>
+                </ListBox>
+                <Separator/>
                 <Label Content="Font size:" VerticalAlignment="Center"/>
                 <ComboBox>
                     <ComboBoxItem Content="10"/>
@@ -85,12 +110,7 @@
                 </Button>
                 <RadioButton GroupName="XXX" Content="Radio" />
                 <RadioButton GroupName="XXX" Content="Ga Ga" />
-                <ToggleButton>
-                    Switch
-                </ToggleButton>
-                <Menu>
-                    <MenuItem>Embedded menu</MenuItem>
-                </Menu>
+                <ToggleButton/>
             </ToolBar>
         </ToolBarTray>
         

--- a/MainDemo.Wpf/MenusAndToolBars.xaml
+++ b/MainDemo.Wpf/MenusAndToolBars.xaml
@@ -76,6 +76,28 @@
                     </ListBoxItem>
                 </ListBox>
                 <Separator/>
+                <ListBox Style="{StaticResource MaterialDesignToolToggleFlatListBox}" SelectedIndex="0">
+                    <ListBox.ToolTip>
+                        <StackPanel>
+                            <TextBlock Text="MaterialDesignToolToggleFlatListBox" />
+                            <TextBlock Text="Exclusive selection" />
+                            <TextBlock Text="ListBoxAssist.IsToggle allows more natural toggle behaviour" />
+                        </StackPanel>
+                    </ListBox.ToolTip>
+                    <ListBoxItem >
+                        <materialDesign:PackIcon Kind="FormatAlignLeft"/>
+                    </ListBoxItem>
+                    <ListBoxItem>
+                        <materialDesign:PackIcon Kind="FormatAlignCenter"/>
+                    </ListBoxItem>
+                    <ListBoxItem>
+                        <materialDesign:PackIcon Kind="FormatAlignRight"/>
+                    </ListBoxItem>
+                    <ListBoxItem>
+                        <materialDesign:PackIcon Kind="FormatAlignJustify"/>
+                    </ListBoxItem>
+                </ListBox>
+                <Separator/>
                 <ListBox SelectionMode="Extended" Style="{StaticResource MaterialDesignToolToggleFlatListBox}">
                     <ListBox.ToolTip>
                         <StackPanel>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Dark.xaml
@@ -8,6 +8,7 @@
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FF000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FF303030" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FF424242" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignToolBarBackground" Color="#FF212121" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DDFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#89FFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignColumnHeader" Color="#BCFFFFFF" po:Freeze="True" /><!-- 74% -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Light.xaml
@@ -8,6 +8,7 @@
     <SolidColorBrush x:Key="MaterialDesignBackground" Color="#FFFFFFFF" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignPaper" Color="#FFfafafa" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignCardBackground" Color="#FFFFFFFF" po:Freeze="True" />
+    <SolidColorBrush x:Key="MaterialDesignToolBarBackground" Color="#FFF5F5F5" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBody" Color="#DD000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignBodyLight" Color="#89000000" po:Freeze="True" />
     <SolidColorBrush x:Key="MaterialDesignColumnHeader" Color="#BC000000" po:Freeze="True" /> <!-- 74% -->

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml
@@ -26,9 +26,12 @@
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignDivider}"/>
-        <Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
+        <Setter Property="TextBlock.FontWeight" Value="DemiBold"/>
+        <Setter Property="TextBlock.FontSize" Value="18"/>
+        <Setter Property="MinWidth" Value="54"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-        <Setter Property="Padding" Value="14 6 14 6" />
+        <Setter Property="Padding" Value="16" />
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -103,7 +106,7 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <Grid Margin="0 0 -1 0">
+                        <Grid>
                             <Border x:Name="MouseOverBorder"
                                     Opacity="0"
                                     Background="{TemplateBinding Foreground, Converter={StaticResource BrushRoundConverter}}"/>
@@ -120,12 +123,11 @@
                                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
                                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                         Padding="{TemplateBinding Padding}">
-
                             </wpf:Ripple>
                             <Border x:Name="SelectedBorder"
                                     Visibility="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=ListBox}, Path=SelectionMode, Converter={StaticResource EqualityToVisibilityConverter}, ConverterParameter={x:Static SelectionMode.Extended}, Mode=OneWay}"
                                     Opacity="0"
-                                    BorderThickness="1 0 1 0"
+                                    BorderThickness="0"
                                     BorderBrush="{DynamicResource MaterialDesignDivider}" />
                         </Grid>
                     </Border>
@@ -178,7 +180,7 @@
                             Background="{TemplateBinding Background}" 
                             SnapsToDevicePixels="true"
                             Padding="{TemplateBinding Padding}">
-                        <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" HorizontalAlignment="Left">
+                        <wpf:Card wpf:ShadowAssist.ShadowDepth="{TemplateBinding wpf:ShadowAssist.ShadowDepth}" HorizontalAlignment="Left" Background="{DynamicResource MaterialDesignToolBarBackground}">
                             <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                         </wpf:Card>
                     </Border>
@@ -205,7 +207,7 @@
         <Setter Property="BorderThickness" Value="0"/>
 		<Setter Property="HorizontalContentAlignment" Value="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
 		<Setter Property="VerticalContentAlignment" Value="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"/>
-		<Setter Property="Padding" Value="8" />
+		<Setter Property="Padding" Value="8"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
 		<Setter Property="Template">
 			<Setter.Value>
@@ -343,8 +345,7 @@
         </Setter>
     </Style>
     
-    <Style x:Key="MaterialDesignCardsListBox" TargetType="{x:Type ListBox}"
-           BasedOn="{StaticResource MaterialDesignListBox}">                
+    <Style x:Key="MaterialDesignCardsListBox" TargetType="{x:Type ListBox}" BasedOn="{StaticResource MaterialDesignListBox}">                
         <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignCardsListBoxItem}"/>        
     </Style>
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Menu.xaml
@@ -76,6 +76,12 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type MenuItem}">
+                    <ControlTemplate.Resources>
+                        <Style TargetType="{x:Type wpf:PackIcon}" >
+                            <Setter Property="Width" Value="16" />
+                            <Setter Property="Height" Value="16" />
+                        </Style>
+                    </ControlTemplate.Resources>
                     <Grid ClipToBounds="True">
                         <Border x:Name="templateRoot"
                                 BorderBrush="{TemplateBinding BorderBrush}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -9,6 +9,7 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.RadioButton.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.TextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.Button.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.ToggleButton.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/materialdesigntheme.Font.xaml" />
     </ResourceDictionary.MergedDictionaries>
@@ -16,7 +17,7 @@
     <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     
     <Style x:Key="MaterialDesignToolBarVerticalOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}"/>
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
         <Setter Property="MinHeight" Value="0"/>
         <Setter Property="MinWidth" Value="0"/>
         <Setter Property="Template">
@@ -51,7 +52,7 @@
     </Style>
     
     <Style x:Key="MaterialDesignToolBarHorizontalOverflowButtonStyle" TargetType="{x:Type ToggleButton}">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}"/>
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
         <Setter Property="MinHeight" Value="0"/>
         <Setter Property="MinWidth" Value="0"/>
         <Setter Property="Template">
@@ -118,7 +119,7 @@
     </Style>
     
     <Style x:Key="MaterialDesignToolBar" TargetType="{x:Type ToolBar}">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}"/>
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
         <Setter Property="FontFamily" Value="{StaticResource MaterialDesignFont}"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
         <Setter Property="ClipToBounds" Value="True"/>
@@ -133,9 +134,12 @@
                                           Style="{StaticResource MaterialDesignToolBarHorizontalOverflowButtonStyle}"
                                           Foreground="{TemplateBinding Foreground}"
                                           />
-                            <Popup x:Name="OverflowPopup" AllowsTransparency="true" Focusable="false" IsOpen="{Binding IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom" StaysOpen="false" Margin="1"
-                                   CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
-                                <Border x:Name="ToolBarSubMenuBorder" BorderBrush="{DynamicResource MaterialDesignDivider}" BorderThickness="1" Background="{DynamicResource MaterialDesignPaper}"
+                            <Popup x:Name="OverflowPopup" AllowsTransparency="true" Focusable="false" IsOpen="{Binding IsOverflowOpen, RelativeSource={RelativeSource TemplatedParent}}" PopupAnimation="{DynamicResource {x:Static SystemParameters.ComboBoxPopupAnimationKey}}" Placement="Bottom" StaysOpen="false" Margin="1">
+                                <!-- warning, this will cache the inner item as well, consider separating the shadow from the item if possible -->
+                                <Popup.CacheMode>
+                                    <BitmapCache EnableClearType="True" SnapsToDevicePixels="True"/>
+                                </Popup.CacheMode>
+                                <Border x:Name="ToolBarSubMenuBorder" BorderBrush="{DynamicResource MaterialDesignDivider}" BorderThickness="1" Background="{DynamicResource MaterialDesignToolBarBackground}"
                                                 TextBlock.FontWeight="ExtraBold"
                                                 CornerRadius="2" Margin="1"
                                                 Effect="{StaticResource MaterialDesignShadowDepth2}" RenderOptions.ClearTypeHint="Enabled">
@@ -147,9 +151,9 @@
                         </Grid>
                         <Border x:Name="MainPanelBorder" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" Style="{StaticResource MaterialDesignToolBarMainPanelBorderStyle}">
                             <DockPanel KeyboardNavigation.TabIndex="1" KeyboardNavigation.TabNavigation="Local">
-                                <Thumb x:Name="ToolBarThumb" Margin="-3,-1,0,0" Padding="6,5,1,6" Style="{StaticResource MaterialDesignToolBarThumbStyle}" Width="10"/>
+                                <Thumb x:Name="ToolBarThumb" Margin="-3,-1,4,0" Padding="6,5,1,3" Style="{StaticResource MaterialDesignToolBarThumbStyle}" Width="10"/>
                                 <ContentPresenter x:Name="ToolBarHeader" ContentSource="Header" HorizontalAlignment="Center" Margin="4,0,4,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" VerticalAlignment="Center"/>
-                                <ToolBarPanel x:Name="PART_ToolBarPanel" IsItemsHost="true" Margin="0,1,2,2" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                                <ToolBarPanel x:Name="PART_ToolBarPanel" IsItemsHost="true" Margin="0,0,2,0" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
                             </DockPanel>
                         </Border>
                     </DockPanel>
@@ -181,7 +185,7 @@
                             <Setter Property="VerticalAlignment" TargetName="OverflowGrid" Value="Bottom"/>
                             <Setter Property="Placement" TargetName="OverflowPopup" Value="Right"/>
                             <Setter Property="Margin" TargetName="MainPanelBorder" Value="0,0,0,11"/>
-                            <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}"/>
+                            <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Opacity" Value=".56"/>
@@ -204,10 +208,15 @@
     <Style x:Key="{x:Static ToolBar.RadioButtonStyleKey}" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}">
         <Setter Property="Margin" Value="8 0 8 0" />
     </Style>
+    <Style TargetType="{x:Type wpf:PackIcon}" >
+        <Setter Property="Width" Value="22" />
+        <Setter Property="Height" Value="22" />
+    </Style>
     <Style x:Key="{x:Static ToolBar.SeparatorStyleKey}" TargetType="Separator">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignDivider}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource MaterialDesignDivider}"/>
         <Setter Property="MinHeight" Value="1"/>
+        <Setter Property="Margin" Value="6 11 6 11"/>
         <Setter Property="SnapsToDevicePixels" Value="true"/>
         <Setter Property="Template">
             <Setter.Value>
@@ -225,25 +234,31 @@
     </Style>
 
     <Style x:Key="{x:Static ToolBar.ButtonStyleKey}" TargetType="Button">
+        <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Padding" Value="16"/>
         <Setter Property="HorizontalContentAlignment" Value="Center"/>
         <Setter Property="VerticalContentAlignment" Value="Center"/>
         <Setter Property="TextBlock.FontWeight" Value="DemiBold"/>
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
-        <Setter Property="wpf:RippleAssist.IsCentered" Value="True"/>
+        <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesignFlatButtonRipple}" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="{x:Type Button}">
-                    <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
+                <ControlTemplate TargetType="{x:Type Button}" >
+                    <Border Background="Transparent" x:Name="border" CornerRadius="2">
+                        <wpf:Ripple Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Focusable="False"
                                 Feedback="{TemplateBinding Foreground}"
-                                ClipToBounds="False"
                                 HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}" 
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Padding="{TemplateBinding Padding}" 
                                 SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                    </Border>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsEnabled" Value="false">
                             <Setter Property="Opacity" Value=".56"/>
+                        </Trigger>
+                        <Trigger Property="IsMouseOver" Value="true">
+                            <Setter Property="BorderBrush" TargetName="border" Value="{DynamicResource MaterialDesignFlatButtonClick}"/>
+                            <Setter Property="Background" TargetName="border" Value="{DynamicResource MaterialDesignFlatButtonClick}"/>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBar.xaml
@@ -126,6 +126,12 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ToolBar}">
+                    <ControlTemplate.Resources>
+                        <Style TargetType="{x:Type wpf:PackIcon}" >
+                            <Setter Property="Width" Value="22" />
+                            <Setter Property="Height" Value="22" />
+                        </Style>
+                    </ControlTemplate.Resources>
                     <DockPanel x:Name="Grid" Margin="3,1,1,1" SnapsToDevicePixels="true" Background="{TemplateBinding Background}">
                         <Grid DockPanel.Dock="Right" x:Name="OverflowGrid" HorizontalAlignment="Right">
                             <ToggleButton x:Name="OverflowButton" ClickMode="Press" FocusVisualStyle="{x:Null}" 
@@ -207,10 +213,6 @@
     </Style>
     <Style x:Key="{x:Static ToolBar.RadioButtonStyleKey}" TargetType="{x:Type RadioButton}" BasedOn="{StaticResource MaterialDesignRadioButton}">
         <Setter Property="Margin" Value="8 0 8 0" />
-    </Style>
-    <Style TargetType="{x:Type wpf:PackIcon}" >
-        <Setter Property="Width" Value="22" />
-        <Setter Property="Height" Value="22" />
     </Style>
     <Style x:Key="{x:Static ToolBar.SeparatorStyleKey}" TargetType="Separator">
         <Setter Property="Background" Value="{DynamicResource MaterialDesignDivider}"/>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBarTray.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ToolBarTray.xaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style x:Key="MaterialDesignToolBarTray" TargetType="{x:Type ToolBarTray}">
-        <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}"/>
+        <Setter Property="Background" Value="{DynamicResource MaterialDesignToolBarBackground}"/>
     </Style>
 </ResourceDictionary>


### PR DESCRIPTION
- Changed ToolBar and ToolBarTray background to match MD
- Tweaked MaterialDesignToolToggleFlatListBox to flawlessly integrate
into ToolBar
- Tweaked ToolBar Button style to match
- Tweaked Separator to match Google's example
- Added support for TextBlock in MaterialDesignToolToggleFlatListBox (with Font set to match icon size) 

I used "App Bar" as background color for ToolBar
https://material.google.com/style/color.html#color-themes
And these ToolBar examples as a reference
https://material.google.com/components/menus.html#menus-usage
