### PR TITLE
Improved support of transition offsets when using ItemsControl

### DIFF
--- a/MaterialDesignThemes.Wpf/Transitions/IndexedItemOffsetMultiplierExtension.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/IndexedItemOffsetMultiplierExtension.cs
@@ -68,6 +68,15 @@ namespace MaterialDesignThemes.Wpf.Transitions
                 multiplier = itemsControl.Items.IndexOf(element);
             }
 
+            if (multiplier == -1) //still not found, repeat now using datacontext
+            {
+                var frameworkElement = element as FrameworkElement;
+                if (frameworkElement != null)
+                {
+                    multiplier = itemsControl.Items.IndexOf(frameworkElement.DataContext);
+                }
+            }
+
             return multiplier > -1 ? new TimeSpan(Unit.Ticks * multiplier) : TimeSpan.Zero;
         }
     }


### PR DESCRIPTION
When attempting to use `IndexedItemOffsetMultiplierExtension` with an `ItemsControl`, all the items would animate at the same time instead of adhering to the specified offset; changing to a `ListBox` and `ListView` would fix any issues I was having.

Upon further inspection, I noticed that when using just an `ItemsControl`, the first multipler retrieval attempt (shown below) would fail and fallback onto `itemsControl.Items.IndexOf(element)`. However, this would try to retrieve the index for the `TransitioningContent` data template instead of the actual item.
```
var multiplier = itemsControl.ItemContainerGenerator.IndexFromContainer(container);
if (multiplier == -1) //container generation may not have completed
{
       multiplier = itemsControl.Items.IndexOf(element);
}
```

By updating this and retrieving the index of the element's `DataContext`, a valid index could be retrieved. I think the change could be simplified to replace the current `IndexOf(element)` with `IndexOf(element.DataContext`) but I don't think it's worth the risk to change, but instead add an extra check if the first attempt fails.
