### PR TITLE
Only allow focus on the ToggleButton in the PopupBox templates

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PopupBox.xaml
@@ -25,6 +25,7 @@
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth3" />
         <Setter Property="TextElement.FontWeight" Value="Normal" />
         <Setter Property="Padding" Value="0 8 0 8" />
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
@@ -160,6 +161,7 @@
         <Setter Property="wpf:ShadowAssist.ShadowDepth" Value="Depth2" />
         <Setter Property="Width" Value="56" />
         <Setter Property="Height" Value="56" />
+        <Setter Property="Focusable" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type wpf:PopupBox}">
@@ -235,7 +237,7 @@
                                                         SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                                 <!-- additional layer so we don't rotate the ripple directly which can cause jumpyness under certain layouts -->
                                                 <ContentControl Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                                RenderTransformOrigin=".5,.5">
+                                                                RenderTransformOrigin=".5,.5" Focusable="False">
                                                     <ContentControl.RenderTransform>
                                                         <RotateTransform x:Name="ContentRotateTransform" Angle="0" />
                                                     </ContentControl.RenderTransform>
@@ -316,13 +318,14 @@
                                       ToolTipService.Placement="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=wpf:PopupBox}, Path=(ToolTipService.Placement)}">
                             <Grid>
                                 <ContentControl x:Name="StandardToggleContent" Content="{TemplateBinding ToggleContent}" ContentTemplate="{TemplateBinding ToggleContentTemplate}"
-                                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource InvertedNullVisibilityConverter}}"/>
+                                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource InvertedNullVisibilityConverter}}" Focusable="False"/>
                                 <ContentControl x:Name="ExplicitToggleContent" Content="{TemplateBinding ToggleContent}" ContentTemplate="{TemplateBinding ToggleContentTemplate}"
-                                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource NullVisibilityConverter}}"/>
+                                                Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource NullVisibilityConverter}}" Focusable="False"/>
                                 <ContentControl x:Name="ExplicitToggleCheckedContent" Content="{TemplateBinding ToggleCheckedContent}" ContentTemplate="{TemplateBinding ToggleCheckedContentTemplate}"
                                                 Visibility="{TemplateBinding ToggleCheckedContent, Converter={StaticResource NullVisibilityConverter}}"
                                                 Opacity="0"
-                                                RenderTransformOrigin=".5,.5">
+                                                RenderTransformOrigin=".5,.5"
+                                                Focusable="False">
                                     <ContentControl.RenderTransform>
                                         <RotateTransform Angle="-45" />
                                     </ContentControl.RenderTransform>


### PR DESCRIPTION
**Before fix**; Focus is set to several of the objects in the template when using tab key.
![popupbox focus bug](https://cloud.githubusercontent.com/assets/1052748/22691632/9f491faa-ed3b-11e6-95d5-f8e740d0a55c.gif)

**After fix**; Focus is only set on the PopupBox togglebutton when tabbing.
![popupbox focus bug fixed](https://cloud.githubusercontent.com/assets/1052748/22691633/9f49291e-ed3b-11e6-8c79-b65a71af8168.gif)
