### PR TITLE
Fix content cover remaining visible.

### DIFF
--- a/MainDemo.Wpf/Home.xaml
+++ b/MainDemo.Wpf/Home.xaml
@@ -31,7 +31,8 @@
             <StackPanel Grid.Column="1" Margin="24 0 0 0" VerticalAlignment="Center">
                 <TextBlock Style="{StaticResource MaterialDesignDisplay1TextBlock}" TextWrapping="Wrap">Welcome to Material Design In XAML Toolkit</TextBlock>
                 <Button Style="{StaticResource MaterialDesignFlatButton}"
-                        Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}">
+                        Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
+                        CommandParameter="{x:Static Dock.Left}">
                     <StackPanel Orientation="Horizontal">
                         <materialDesign:PackIcon Kind="Binoculars" />
                         <TextBlock Margin="8 0 0 0">EXPLORE</TextBlock>


### PR DESCRIPTION
Reproduction steps:
1. Launch the WPF test application
2. Select the EXPLORE button on the home page
3. Make a section from items on the left

Observed: The content cover remains visible after the left drawer is dismissed.

The reason is because the command was not passing any Dock value as its command parameter. This was causing all of the Is*DrawerOpenProperty to be set to true. thus keeping the content cover visible after only the left drawer is dismissed. 

The change here fixes the issue by specifying that only the left drawer should be opened. 