### PR TITLE
Validation error display for RadioButtons and CheckBoxes

### DIFF
--- a/MainDemo.Wpf/Buttons.xaml
+++ b/MainDemo.Wpf/Buttons.xaml
@@ -6,6 +6,7 @@
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:wpfExample="clr-namespace:MaterialDesignColors.WpfExample"
+             xmlns:domain="clr-namespace:MaterialDesignDemo.Domain"
              mc:Ignorable="d" 
              d:DesignHeight="500" d:DesignWidth="800">
     <UserControl.Resources>
@@ -254,7 +255,14 @@
                 </ToggleButton>
             </StackPanel>
             <StackPanel Grid.Row="1" Margin="0 16 0 0" Orientation="Horizontal">
-                <RadioButton Style="{StaticResource MaterialDesignRadioButton}" Margin="0 0 8 8" VerticalAlignment="Center" IsChecked="True">
+                <RadioButton Style="{StaticResource MaterialDesignRadioButton}" Margin="0 0 8 8" VerticalAlignment="Center" Tag="True">
+                    <RadioButton.IsChecked>
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}">
+                            <Binding.ValidationRules>
+                                <domain:IsCheckedValidationRule />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </RadioButton.IsChecked>
                     Radio
                 </RadioButton>
                 <RadioButton Style="{StaticResource MaterialDesignRadioButton}" Margin="0 0 8 8" VerticalAlignment="Center">
@@ -267,7 +275,14 @@
                 <CheckBox Style="{StaticResource MaterialDesignCheckBox}" Margin="0 0 8 8" VerticalAlignment="Center">
                     Check
                 </CheckBox>
-                <CheckBox Style="{StaticResource MaterialDesignCheckBox}" Margin="0 0 8 8" VerticalAlignment="Center" IsChecked="True">
+                <CheckBox Style="{StaticResource MaterialDesignCheckBox}" Margin="0 0 8 8" VerticalAlignment="Center" Tag="True">
+                    <CheckBox.IsChecked>
+                        <Binding Path="Tag" RelativeSource="{RelativeSource Self}">
+                            <Binding.ValidationRules>
+                                <domain:IsCheckedValidationRule />
+                            </Binding.ValidationRules>
+                        </Binding>
+                    </CheckBox.IsChecked>
                     Mate
                 </CheckBox>
                 <CheckBox Style="{StaticResource MaterialDesignCheckBox}" Margin="0 0 8 8" VerticalAlignment="Center" 
@@ -275,7 +290,7 @@
                     Disabled
                 </CheckBox>
             </StackPanel>
-            <StackPanel Grid.Row="2"  Margin="0 16 0 0" Orientation="Horizontal">
+            <StackPanel Grid.Row="2" Margin="0 16 0 0" Orientation="Horizontal">
                 <ToggleButton Style="{StaticResource MaterialDesignSwitchToggleButton}" VerticalAlignment="Center"
                           ToolTip="Default ToggleButton Style"/>
                 <ToggleButton Style="{StaticResource MaterialDesignSwitchToggleButton}" VerticalAlignment="Center" Margin="8 0 0 0" IsEnabled="False" />
@@ -299,7 +314,7 @@
                     </materialDesign:ToggleButtonAssist.OnContent>
                 </ToggleButton>
             </StackPanel>
-            <StackPanel Grid.Row="3"  Margin="0 16 0 0" Orientation="Horizontal">
+            <StackPanel Grid.Row="3" Margin="0 16 0 0" Orientation="Horizontal">
                 <ToggleButton Style="{StaticResource MaterialDesignFlatToggleButton}" ToolTip="MaterialDesignFlatToggleButton">
                     <materialDesign:PackIcon Kind="Paperclip" Height="21" Width="21" />
                 </ToggleButton>
@@ -338,7 +353,7 @@
                     <materialDesign:PackIcon Kind="FormatAlignJustify"/>
                 </ListBoxItem>
             </ListBox>
-            <ListBox  Grid.Column="1" Grid.Row="2"  SelectionMode="Extended" Style="{StaticResource MaterialDesignToolToggleFlatListBox}">
+            <ListBox  Grid.Column="1" Grid.Row="2" SelectionMode="Extended" Style="{StaticResource MaterialDesignToolToggleFlatListBox}">
                 <ListBox.ToolTip>
                     <StackPanel>
                         <TextBlock Text="MaterialDesignToolToggleListBox" />

--- a/MainDemo.Wpf/Domain/IsCheckedValidationRule.cs
+++ b/MainDemo.Wpf/Domain/IsCheckedValidationRule.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Controls;
+
+namespace MaterialDesignDemo.Domain
+{
+    public class IsCheckedValidationRule : ValidationRule
+    {
+        public override ValidationResult Validate(object value, CultureInfo cultureInfo)
+        {
+            if( value is bool && (bool) value)
+            {
+                return ValidationResult.ValidResult;
+            }
+            return new ValidationResult(false, "Option must be checked");
+        }
+    }
+}

--- a/MainDemo.Wpf/MaterialDesignDemo.csproj
+++ b/MainDemo.Wpf/MaterialDesignDemo.csproj
@@ -93,6 +93,7 @@
     </Compile>
     <Compile Include="Domain\DocumentationLinkType.cs" />
     <Compile Include="Domain\FutureDateValidationRule.cs" />
+    <Compile Include="Domain\IsCheckedValidationRule.cs" />
     <Compile Include="Domain\MainWindowViewModel.cs" />
     <Compile Include="Domain\NotEmptyValidationRule.cs" />
     <Compile Include="Domain\NotifyPropertyChangedExtension.cs" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.CheckBox.xaml
@@ -2,7 +2,8 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />    
+        <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ToggleButton.xaml" />
+        <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="FocusVisual">
@@ -51,6 +52,7 @@
         <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
@@ -125,6 +127,10 @@
                             <Setter Property="Data" TargetName="Graphic" Value="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
                             <Setter Property="Opacity" TargetName="Graphic" Value="0.56"/>
                         </Trigger>
+                        <Trigger Property="Validation.HasError" Value="true">
+                            <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource ValidationErrorBrush}" />
+                            <Setter Property="Control.Foreground" TargetName="contentPresenter" Value="{DynamicResource ValidationErrorBrush}" />
+                        </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
@@ -153,6 +159,7 @@
         <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}"/>
         <Setter Property="BorderThickness" Value="1"/>
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type CheckBox}">
@@ -222,6 +229,10 @@
                         <Trigger Property="IsChecked" Value="{x:Null}">
                             <Setter Property="Data" TargetName="Graphic" Value="M10,17L5,12L6.41,10.58L10,14.17L17.59,6.58L19,8M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
                             <Setter Property="Opacity" TargetName="Graphic" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="Validation.HasError" Value="true">
+                            <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource ValidationErrorBrush}" />
+                            <Setter Property="Control.Foreground" TargetName="contentPresenter" Value="{DynamicResource ValidationErrorBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.RadioButton.xaml
@@ -1,5 +1,9 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="MaterialDesignTheme.ValidationErrorTemplate.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+    
     <Style x:Key="OptionMarkFocusVisual">
         <Setter Property="Control.Template">
             <Setter.Value>
@@ -24,6 +28,7 @@
         <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type FrameworkElement}}, Path=(TextElement.Foreground)}"/>
         <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource PrimaryHueMidBrush}"/>
+        <Setter Property="Validation.ErrorTemplate" Value="{StaticResource MaterialDesignValidationErrorTemplate}"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RadioButton}">
@@ -95,6 +100,10 @@
                         <Trigger Property="IsChecked" Value="{x:Null}">
                             <Setter Property="Data" TargetName="Graphic" Value="M12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,7A5,5 0 0,0 7,12A5,5 0 0,0 12,17A5,5 0 0,0 17,12A5,5 0 0,0 12,7Z" />
                             <Setter Property="Opacity" TargetName="Graphic" Value="0.56"/>
+                        </Trigger>
+                        <Trigger Property="Validation.HasError" Value="true">
+                            <Setter Property="Fill" TargetName="Graphic" Value="{DynamicResource ValidationErrorBrush}" />
+                            <Setter Property="Control.Foreground" TargetName="contentPresenter" Value="{DynamicResource ValidationErrorBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
Fixes issue #370.
Added validation template to check boxes and radio button.

Looking through the [material design docs](https://material.io/guidelines/patterns/errors.html) I could not find any guidelines on exactly how to style things like the checkbox and radio button (I suspect because validation on these is a very rare case). IMO I like it when the graphic and the content are both turned red so that is how they are implemented. I am happy to remove this and just have the red text below the control if that is preferred as well. 

I have added validation to a radio button and check box on the buttons demo pages so you can see the result.