### PR TITLE
Fix cell background color display when selecting multiple cells.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.DataGrid.xaml
@@ -175,12 +175,13 @@
             </MultiTrigger>
             <MultiTrigger>
                 <MultiTrigger.Conditions>
-                    <Condition Property="IsSelected" Value="true"/>
+                    <Condition Property="IsSelected" Value="True"/>
                     <Condition Property="Selector.IsSelectionActive" Value="True"/>
                 </MultiTrigger.Conditions>
                 <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}"/>
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignSelection}" />
             </MultiTrigger>
-            <Trigger Property="IsEnabled" Value="false">
+            <Trigger Property="IsEnabled" Value="False">
                 <Setter Property="Opacity" Value=".56"/>
             </Trigger>
         </Style.Triggers>


### PR DESCRIPTION
Fixes issue #310
When the cell is selected, set the background color so that the cell's background color matches the color used when the entire row is selected. 