### PR TITLE
Improved control over DialogHost popup

### DIFF
--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -416,8 +416,8 @@ namespace MaterialDesignThemes.Wpf
 
         public Style PopupStyle
         {
-            get => (Style) GetValue(PopupStyleProperty);
-            set => SetValue(PopupStyleProperty, value);
+            get { return (Style) GetValue(PopupStyleProperty); }
+            set { SetValue(PopupStyleProperty, value); }
         }
 
         public override void OnApplyTemplate()

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -411,6 +411,15 @@ namespace MaterialDesignThemes.Wpf
             set { SetValue(SnackbarMessageQueueProperty, value); }
         }
 
+        public static readonly DependencyProperty PopupStyleProperty = DependencyProperty.Register(
+            nameof(PopupStyle), typeof(Style), typeof(DialogHost), new PropertyMetadata(default(Style)));
+
+        public Style PopupStyle
+        {
+            get => (Style) GetValue(PopupStyleProperty);
+            set => SetValue(PopupStyleProperty, value);
+        }
+
         public override void OnApplyTemplate()
         {
             if (_contentCoverGrid != null)

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -470,9 +470,17 @@
         </Style.Triggers>
     </Style>
 
+    <Style x:Key="MaterialDesignDialogHostPopup" TargetType="{x:Type controlzEx:PopupEx}">
+        <Setter Property="StaysOpen" Value="True" />
+        <Setter Property="AllowsTransparency" Value="True" />
+        <Setter Property="PopupAnimation" Value="None" />
+        <Setter Property="Placement" Value="Center" />
+    </Style>
+    
     <Style TargetType="{x:Type local:DialogHost}">
         <Setter Property="DialogMargin" Value="22" />
         <Setter Property="local:ShadowAssist.ShadowDepth" Value="Depth5" />
+        <Setter Property="PopupStyle" Value="{StaticResource MaterialDesignDialogHostPopup}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="local:DialogHost">
@@ -596,13 +604,9 @@
                                 </VisualState>
                             </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
-                        <controlzEx:PopupEx IsOpen="False"
-                                          PlacementTarget="{Binding ElementName=DialogHostRoot, Mode=OneWay}"                                            
-                                          StaysOpen="True"
-                                          AllowsTransparency="True"
-                                          PopupAnimation="None"
-                                          x:Name="PART_Popup"
-                                          Placement="Center">
+                        <controlzEx:PopupEx PlacementTarget="{Binding ElementName=DialogHostRoot, Mode=OneWay}"
+                                            x:Name="PART_Popup"
+                                            Style="{TemplateBinding PopupStyle}">
                             <controlzEx:PopupEx.Resources>
                                 <ResourceDictionary>
                                     <ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
Address issue #655 though not in the way requested.

Added a style to control the Popup in the dialog host and created a default style that would allow consumers to either extend or override the default values as they see fit.
I personally like this option better than simply adding an attached property because it gives greater control and is more discoverable.
