### PR TITLE
Clipped shadows

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/ShadowConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowConverter.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media.Effects;
 
@@ -12,29 +7,13 @@ namespace MaterialDesignThemes.Wpf.Converters
 {
     public class ShadowConverter : IValueConverter
     {
-        private static readonly IDictionary<ShadowDepth, DropShadowEffect> ShadowsDictionary;
         public static readonly ShadowConverter Instance = new ShadowConverter();
-
-        static ShadowConverter()
-        {
-            var resourceDictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml", UriKind.Absolute) };
-
-            ShadowsDictionary = new Dictionary<ShadowDepth, DropShadowEffect>
-            {
-                { ShadowDepth.Depth0, null },
-                { ShadowDepth.Depth1, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth1"] },
-                { ShadowDepth.Depth2, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth2"] },
-                { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
-                { ShadowDepth.Depth4, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth4"] },
-                { ShadowDepth.Depth5, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth5"] },
-            };
-        }
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!(value is ShadowDepth)) return null;
 
-            return Clone(ShadowsDictionary[(ShadowDepth) value]);
+            return Clone(ShadowInfo.GetDropShadow((ShadowDepth) value));
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/MaterialDesignThemes.Wpf/Converters/ShadowEdgeConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowEdgeConverter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Effects;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class ShadowEdgeConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values?.Length != 4)
+            {
+                return Binding.DoNothing;
+            }
+
+            if (!(values[0] is double) || !(values[1] is double) || !(values[2] is ShadowDepth) ||
+                !(values[3] is ShadowEdges))
+            {
+                return Binding.DoNothing;
+            }
+
+            double width = (double)values[0];
+            double height = (double)values[1];
+            if (double.IsNaN(width) || double.IsInfinity(width) || double.IsNaN(height) || double.IsInfinity(height))
+            {
+                return Binding.DoNothing;
+            }
+            DropShadowEffect dropShadow = ShadowInfo.GetDropShadow((ShadowDepth)values[2]);
+            if (dropShadow == null)
+            {
+                return Binding.DoNothing;
+            }
+
+            ShadowEdges edges = (ShadowEdges)values[3];
+            double blurRadius = dropShadow.BlurRadius;
+
+            var rect = new Rect(0, 0, width, height);
+
+            if (edges.HasFlag(ShadowEdges.Left))
+            {
+                rect = new Rect(rect.X - blurRadius, rect.Y, rect.Width + blurRadius, rect.Height);
+            }
+            if (edges.HasFlag(ShadowEdges.Top))
+            {
+                rect = new Rect(rect.X, rect.Y - blurRadius, rect.Width, rect.Height + blurRadius);
+            }
+            if (edges.HasFlag(ShadowEdges.Right))
+            {
+                rect = new Rect(rect.X, rect.Y, rect.Width + blurRadius, rect.Height);
+            }
+            if (edges.HasFlag(ShadowEdges.Bottom))
+            {
+                rect = new Rect(rect.X, rect.Y, rect.Width, rect.Height + blurRadius);
+            }
+
+            var size = new GeometryDrawing(new SolidColorBrush(Colors.White), new Pen(), new RectangleGeometry(rect));
+            return new DrawingBrush(size)
+            {
+                Stretch = Stretch.None,
+                TileMode = TileMode.None,
+                Viewport = rect,
+                ViewportUnits = BrushMappingMode.Absolute,
+                Viewbox = rect,
+                ViewboxUnits = BrushMappingMode.Absolute
+            };
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
+++ b/MaterialDesignThemes.Wpf/Converters/ShadowInfo.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Media.Effects;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    internal static class ShadowInfo
+    {
+        private static readonly IDictionary<ShadowDepth, DropShadowEffect> ShadowsDictionary;
+
+        static ShadowInfo()
+        {
+            var resourceDictionary = new ResourceDictionary { Source = new Uri("pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Shadows.xaml", UriKind.Absolute) };
+
+            ShadowsDictionary = new Dictionary<ShadowDepth, DropShadowEffect>
+            {
+                { ShadowDepth.Depth0, null },
+                { ShadowDepth.Depth1, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth1"] },
+                { ShadowDepth.Depth2, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth2"] },
+                { ShadowDepth.Depth3, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth3"] },
+                { ShadowDepth.Depth4, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth4"] },
+                { ShadowDepth.Depth5, (DropShadowEffect)resourceDictionary["MaterialDesignShadowDepth5"] },
+            };
+        }
+
+        public static DropShadowEffect GetDropShadow(ShadowDepth depth)
+        {
+            return ShadowsDictionary[depth];
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -292,6 +292,8 @@
     <Compile Include="Converters\NotZeroToVisibilityConverter.cs" />
     <Compile Include="Converters\PointValueConverter.cs" />
     <Compile Include="Converters\ShadowConverter.cs" />
+    <Compile Include="Converters\ShadowEdgeConverter.cs" />
+    <Compile Include="Converters\ShadowInfo.cs" />
     <Compile Include="Converters\SizeToRectConverter.cs" />
     <Compile Include="Converters\SnackbarMessageTypeConverter.cs" />
     <Compile Include="Converters\TimeToVisibilityConverter.cs" />

--- a/MaterialDesignThemes.Wpf/ShadowAssist.cs
+++ b/MaterialDesignThemes.Wpf/ShadowAssist.cs
@@ -3,7 +3,6 @@ using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Media.Effects;
-using System.Windows.Navigation;
 
 namespace MaterialDesignThemes.Wpf
 {
@@ -15,6 +14,17 @@ namespace MaterialDesignThemes.Wpf
         Depth3,
         Depth4,
         Depth5
+    }
+
+    [Flags]
+    public enum ShadowEdges
+    {
+        None = 0,
+        Left = 1,
+        Top = 2,
+        Right = 4,
+        Bottom = 8,
+        All = Left | Top | Right | Bottom
     }
 
     internal class ShadowLocalInfo
@@ -111,5 +121,17 @@ namespace MaterialDesignThemes.Wpf
             return (CacheMode)element.GetValue(CacheModeProperty);
         }
 
+        public static readonly DependencyProperty ShadowEdgesProperty = DependencyProperty.RegisterAttached(
+            "ShadowEdges", typeof(ShadowEdges), typeof(ShadowAssist), new PropertyMetadata(ShadowEdges.All));
+
+        public static void SetShadowEdges(DependencyObject element, ShadowEdges value)
+        {
+            element.SetValue(ShadowEdgesProperty, value);
+        }
+
+        public static ShadowEdges GetShadowEdges(DependencyObject element)
+        {
+            return (ShadowEdges) element.GetValue(ShadowEdgesProperty);
+        }
     }
 }

--- a/MaterialDesignThemes.Wpf/Themes/Generic.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/Generic.xaml
@@ -29,12 +29,12 @@
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.SmartHint.xaml" />
         <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Snackbar.xaml" />
     </ResourceDictionary.MergedDictionaries>
-    
+
     <!-- set up default styles for our custom Material Design in XAML Toolkit controls -->
     <Style TargetType="{x:Type local:Clock}" BasedOn="{StaticResource MaterialDesignClock}" />
     <Style TargetType="{x:Type local:PopupBox}" BasedOn="{StaticResource MaterialDesignPopupBox}" />
     <Style TargetType="{x:Type local:TimePicker}" BasedOn="{StaticResource MaterialDesignTimePicker}" />
-        
+
     <converters:BrushToRadialGradientBrushConverter x:Key="BrushToRadialGradientBrushConverter" />
     <converters:DrawerOffsetConverter x:Key="DrawerOffsetConverter" />
 
@@ -46,7 +46,7 @@
         <Setter Property="VerticalAlignment" Value="Stretch" />
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="ClipToBounds" Value="{Binding RelativeSource={RelativeSource Self}, Path=(local:RippleAssist.ClipToBounds)}" />        
+        <Setter Property="ClipToBounds" Value="{Binding RelativeSource={RelativeSource Self}, Path=(local:RippleAssist.ClipToBounds)}" />
         <Setter Property="Feedback" Value="{Binding RelativeSource={RelativeSource Self}, Path=(local:RippleAssist.Feedback)}" />
         <Setter Property="Template">
             <Setter.Value>
@@ -120,10 +120,10 @@
                                                         <SineEase EasingMode="EaseOut" />
                                                     </EasingDoubleKeyFrame.EasingFunction>
                                                 </EasingDoubleKeyFrame>
-                                          </DoubleAnimationUsingKeyFrames>
+                                            </DoubleAnimationUsingKeyFrames>
                                         </Storyboard>
-                                      </VisualTransition>
-                                  </VisualStateGroup.Transitions>
+                                    </VisualTransition>
+                                </VisualStateGroup.Transitions>
                                 <VisualState x:Name="Normal">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetProperty="ScaleX" Storyboard.TargetName="ScaleTransform" To="0"/>
@@ -179,7 +179,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <Style TargetType="{x:Type local:Underline}">
         <Setter Property="Background" Value="{DynamicResource PrimaryHueMidBrush}"/>
         <Setter Property="SnapsToDevicePixels" Value="True"/>
@@ -404,19 +404,30 @@
     </Style>
 
     <Style TargetType="{x:Type local:ColorZone}">
+        <Style.Resources>
+            <converters:ShadowEdgeConverter x:Key="ShadowEdgeConverter" />
+        </Style.Resources>
         <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
         <Setter Property="Foreground" Value="{DynamicResource MaterialDesignBody}" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalAlignment" Value="Top" />
-        <Setter Property="IsTabStop" Value="False" />        
+        <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:ColorZone}">
                     <Grid Background="Transparent">
+                        <Grid.OpacityMask>
+                            <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(local:ShadowAssist.ShadowDepth)" />
+                                <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(local:ShadowAssist.ShadowEdges)" />
+                            </MultiBinding>
+                        </Grid.OpacityMask>
                         <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(local:ShadowAssist.CacheMode)}">
                             <Border Background="{TemplateBinding Background}"
-                                    CornerRadius="{TemplateBinding CornerRadius}"                                
+                                    CornerRadius="{TemplateBinding CornerRadius}"
                                     Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(local:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}">
                             </Border>
                         </AdornerDecorator>
@@ -424,7 +435,7 @@
                                 BorderBrush="{TemplateBinding BorderBrush}"
                                 BorderThickness="{TemplateBinding BorderThickness}"
                                 CornerRadius="{TemplateBinding CornerRadius}"
-                                ClipToBounds="True" >
+                                ClipToBounds="True">
                             <ContentPresenter Content="{TemplateBinding Content}"
                                               ContentTemplate="{TemplateBinding ContentTemplate}"
                                               TextElement.Foreground="{TemplateBinding Foreground}"
@@ -988,7 +999,7 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-    </Style>    
+    </Style>
 
     <Style TargetType="{x:Type local:PackIcon}">
         <Setter Property="Height" Value="16" />
@@ -1015,7 +1026,7 @@
         </Setter>
     </Style>
 
-     <Style TargetType="{x:Type transitions:Transitioner}">
+    <Style TargetType="{x:Type transitions:Transitioner}">
         <Setter Property="ClipToBounds" Value="True" />
         <Setter Property="ItemsPanel">
             <Setter.Value>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Card.xaml
@@ -10,23 +10,34 @@
     <converters:CardClipConverter x:Key="CardClipConverter" />
 
     <ControlTemplate TargetType="{x:Type wpf:Card}" x:Key="CardTemplate">
+        <ControlTemplate.Resources>
+            <converters:ShadowEdgeConverter x:Key="ShadowEdgeConverter" />
+        </ControlTemplate.Resources>
         <Grid Margin="{TemplateBinding Margin}" Background="Transparent">
+            <Grid.OpacityMask>
+                <MultiBinding Converter="{StaticResource ShadowEdgeConverter}">
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualWidth"/>
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="ActualHeight"/>
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowDepth)" />
+                    <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="(wpf:ShadowAssist.ShadowEdges)" />
+                </MultiBinding>
+            </Grid.OpacityMask>
             <AdornerDecorator CacheMode="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ShadowAssist.CacheMode)}">
                 <Border Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
                         CornerRadius="{TemplateBinding UniformCornerRadius}">
                     <Border Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}" 
                             x:Name="PART_ClipBorder"
-                            Clip="{TemplateBinding ContentClip}" />                        
+                            Clip="{TemplateBinding ContentClip}" />
                 </Border>
             </AdornerDecorator>
             <ContentPresenter 
-                x:Name="ContentPresenter"                    
+                x:Name="ContentPresenter"
                 Margin="{TemplateBinding Padding}"
                 Clip="{TemplateBinding ContentClip}"
                 Content="{TemplateBinding ContentControl.Content}" 
                 ContentTemplate="{TemplateBinding ContentControl.ContentTemplate}" 
                 ContentTemplateSelector="{TemplateBinding ContentControl.ContentTemplateSelector}" 
-                ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}">                    
+                ContentStringFormat="{TemplateBinding ContentControl.ContentStringFormat}">
             </ContentPresenter>
         </Grid>
     </ControlTemplate>

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.GroupBox.xaml
@@ -34,7 +34,11 @@
                     <Grid>
                         <Border Background="{TemplateBinding Background}" BorderBrush="{Binding Path=Background, ElementName=PART_ColorZone}" BorderThickness="{TemplateBinding BorderThickness}" />
                         <DockPanel Background="{TemplateBinding Background}">
-                            <wpf:ColorZone UseLayoutRounding="True" x:Name="PART_ColorZone" DockPanel.Dock="Top" Padding="{TemplateBinding Padding}" Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}" Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
+                            <wpf:ColorZone UseLayoutRounding="True" x:Name="PART_ColorZone" DockPanel.Dock="Top" Padding="{TemplateBinding Padding}" 
+                                           Effect="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowDepth), Converter={x:Static converters:ShadowConverter.Instance}}"
+                                           wpf:ShadowAssist.ShadowEdges="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ShadowAssist.ShadowEdges)}"
+                                           Mode="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Mode)}" 
+                                           SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}">
                                 <ContentPresenter ContentSource="Header" RecognizesAccessKey="True" SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
                                                   ContentStringFormat="{TemplateBinding HeaderStringFormat}"
                                                   ContentTemplate="{TemplateBinding HeaderTemplate}"

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Shadows.xaml
@@ -2,7 +2,7 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:po="http://schemas.microsoft.com/winfx/2006/xaml/presentation/options">
     
-	<!--  thanks: http://marcangers.com/material-design-shadows-in-wpf/ -->
+    <!--  thanks: http://marcangers.com/material-design-shadows-in-wpf/ -->
 
     <Color x:Key="MaterialDesignShadow">#AA000000</Color>
     <SolidColorBrush x:Key="MaterialDesignShadowBrush" Color="{StaticResource MaterialDesignShadow}"/>


### PR DESCRIPTION
Adding the ability to control which edges the shadows are rendered on. Typically this is not an issue as you can simply lay another control over the top, but there are cases where it is simpler to simply clip the shadow to only the desired edges.

These changes primary apply to ColorZone and Card, however these are also used in the control templates of other controls so I tried to add in support for setting the attached property where appropriate.

The ShadowEdges enum is flagged so you can easily specify a single or group of edges for the shadow to render on.

Example usage:
```XAML
<materialDesign:ColorZone Mode="Accent" Padding="16" materialDesign:ShadowAssist.ShadowDepth="Depth3" materialDesign:ShadowAssist.ShadowEdges="Bottom,Right">
...
</materialDesign:ColorZone>
```

