### PR TITLE
Allow 12:00am as initial time selection

### DIFF
--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -418,11 +418,14 @@ namespace MaterialDesignThemes.Wpf
 			_clockHostContentControl.SetBinding(StyleProperty, GetBinding(ClockHostContentControlStyleProperty));
 		}
 
-		private void ClockChoiceMadeHandler(object sender, ClockChoiceMadeEventArgs clockChoiceMadeEventArgs)
-		{
-			if (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Minutes)
-				TogglePopup();
-		}
+        private void ClockChoiceMadeHandler(object sender, ClockChoiceMadeEventArgs clockChoiceMadeEventArgs)
+        {
+            TogglePopup();
+            if (SelectedTime == null)
+            {
+                SelectedTime = _clock.Time;
+            }
+        }
 
 		private void DropDownButtonOnClick(object sender, RoutedEventArgs routedEventArgs)
 		{

--- a/MaterialDesignThemes.Wpf/TimePicker.cs
+++ b/MaterialDesignThemes.Wpf/TimePicker.cs
@@ -420,10 +420,13 @@ namespace MaterialDesignThemes.Wpf
 
         private void ClockChoiceMadeHandler(object sender, ClockChoiceMadeEventArgs clockChoiceMadeEventArgs)
         {
-            TogglePopup();
-            if (SelectedTime == null)
+            if (clockChoiceMadeEventArgs.Mode == ClockDisplayMode.Minutes)
             {
-                SelectedTime = _clock.Time;
+                TogglePopup();
+                if (SelectedTime == null)
+                {
+                    SelectedTime = _clock.Time;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #689 

Fixing issue where 12:00am would not be selected as the initial time.
Also clean up whitespace. If this is not desirable let me know and I can re-submit without it.