### PR TITLE
Removing Disabled visual state.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Calendar.xaml
@@ -158,12 +158,6 @@
                                         <DoubleAnimation Duration="0" To="0.5" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="HighlightBackground"/>
                                     </Storyboard>
                                 </VisualState>
-                                <VisualState x:Name="Disabled">
-                                    <Storyboard>
-                                        <DoubleAnimation Duration="0" To="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="HighlightBackground"/>
-                                        <DoubleAnimation Duration="0" To=".35" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="NormalText"/>
-                                    </Storyboard>
-                                </VisualState>
                             </VisualStateGroup>
                             <VisualStateGroup x:Name="SelectionStates">
                                 <VisualStateGroup.Transitions>


### PR DESCRIPTION
Fixes #605 

Under reasonable circumstances I am not sure if the Disabled visual state of the CalendarDayButton is ever used. It appears to be a state that is only referenced from ButtonBase. Comparing with the [default template](https://msdn.microsoft.com/en-us/library/cc278077.aspx) it appears that it is never used.