### PR TITLE
Correct Spelling Mistake

### DIFF
--- a/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
@@ -44,7 +44,7 @@ namespace MaterialDesignThemes.Wpf.Transitions
             "AutoApplyTransitionOrigins", typeof (bool), typeof (Transitioner), new PropertyMetadata(default(bool)));
         
         /// <summary>
-        /// If enabled, trnaisiotns origins will be applied to wipes, according to where a transition was triggered from.  For example, the mouse point where a user clicks a button.
+        /// If enabled, transition origins will be applied to wipes, according to where a transition was triggered from.  For example, the mouse point where a user clicks a button.
         /// </summary>
         public bool AutoApplyTransitionOrigins
         {


### PR DESCRIPTION
Also, should AutoApplyTransitionOrigins still default to false? Regardless, I feel like "new PropertyMetadata(default(bool))" should be changed to "new PropertyMetadata(false)"