### PR TITLE
Fix progress bar with no animation, animating when first shown

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -29,9 +29,9 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                         <Storyboard x:Key="OnLoadedNoAnimation">
-                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="TemplateRoot" To="1" />
-                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="TemplateRoot" To="1" />
-                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)" Storyboard.TargetName="TemplateRoot" To="1" />
+                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.Opacity)" Storyboard.TargetName="TemplateRoot" To="1" Duration="0" />
+                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleX)" Storyboard.TargetName="TemplateRoot" To="1" Duration="0"/>
+                            <DoubleAnimation Storyboard.TargetProperty="(UIElement.RenderTransform).(TransformGroup.Children)[0].(ScaleTransform.ScaleY)" Storyboard.TargetName="TemplateRoot" To="1" Duration="0"/>
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid x:Name="TemplateRoot" RenderTransformOrigin="0,0.5" Opacity="0">


### PR DESCRIPTION
Explicitly setting the duration of the no animation storyboard to 0 from the default of Automatic.

When opening the progress bar page on the example application, all horizontal progress bars animate in. However, the second one has TransitionAssist.DisableTransitions="True" set. Since the default for the Duration property is Automatic, this explicitly sets the Duration to zero for the OnLoadedNoAnimation storyboard.