### PR TITLE
Fix horizontal content alignment on GridViewColumnHeader

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -87,6 +87,9 @@
             <Setter.Value>
                 <ControlTemplate TargetType="GridViewColumnHeader">
                     <DockPanel>
+                        <Thumb x:Name="PART_HeaderGripper"
+                               DockPanel.Dock="Right"
+                               Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />
                         <Border x:Name="HeaderBorder"
                                 Padding="{TemplateBinding Padding}"
                                 BorderThickness="{TemplateBinding BorderThickness}">
@@ -98,10 +101,6 @@
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
                         </Border>
-                        <Thumb x:Name="PART_HeaderGripper"
-                               HorizontalAlignment="Right"
-                               DockPanel.Dock="Right"
-                               Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />
                     </DockPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">


### PR DESCRIPTION
Letting the HeaderBorder fill the dock panel so that the HorizontalAlignment of the ContentPresenter actually changes the position of the content.

Fixes #709 