### PR TITLE
Fixing combo box issue on right screen.

### DIFF
--- a/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
+++ b/MaterialDesignThemes.Wpf/ComboBoxPopup.cs
@@ -13,7 +13,7 @@ namespace MaterialDesignThemes.Wpf
     {
         Undefined,
         Down,
-        Up, 
+        Up,
         Classic
     }
 
@@ -114,7 +114,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         #endregion
-        
+
         #region Background property
 
         private static readonly DependencyPropertyKey BackgroundPropertyKey =
@@ -233,9 +233,9 @@ namespace MaterialDesignThemes.Wpf
             SetupVisiblePlacementWidth(visualAncestry);
 
             var data = GetPositioningData(visualAncestry, popupSize, targetSize, offset);
-            var preferUpIfSafe = data.LocationY + data.PopupSize.Height > data.ScreenHeight;            
+            var preferUpIfSafe = data.LocationY + data.PopupSize.Height > data.ScreenHeight;
 
-            if (ClassicMode 
+            if (ClassicMode
                 || data.LocationX + data.PopupSize.Width - data.RealOffsetX > data.ScreenWidth
                 || data.LocationX - data.RealOffsetX < 0
                 || !preferUpIfSafe && data.LocationY - Math.Abs(data.NewDownY) < 0)
@@ -274,10 +274,10 @@ namespace MaterialDesignThemes.Wpf
             var screen = Screen.FromPoint(locationFromScreen);
             var screenWidth = (int)DpiHelper.TransformToDeviceX(mainVisual, (int)screen.Bounds.Width);
             var screenHeight = (int)DpiHelper.TransformToDeviceY(mainVisual, (int)screen.Bounds.Height);
-
+            
             //Adjust the location to be in terms of the current screen
-            var locationX = (int)locationFromScreen.X % screenWidth - screen.Bounds.X;
-            var locationY = (int)locationFromScreen.Y % screenHeight - screen.Bounds.Y;
+            var locationX = (int)(locationFromScreen.X - screen.Bounds.X) % screenWidth;
+            var locationY = (int)(locationFromScreen.Y - screen.Bounds.Y) % screenHeight;
 
             var upVerticalOffsetIndepent = DpiHelper.TransformToDeviceY(mainVisual, UpVerticalOffset);
             var newUpY = upVerticalOffsetIndepent - popupSize.Height + targetSize.Height;
@@ -330,8 +330,8 @@ namespace MaterialDesignThemes.Wpf
                 case ComboBoxPopupPlacement.Up:
                     SetChildTemplateIfNeed(UpContentTemplate);
                     break;
-//                default:
-//                    throw new NotImplementedException($"Unexpected value {placement} of the {nameof(PopupPlacement)} property inside the {nameof(ComboBoxPopup)} control.");
+                    //                default:
+                    //                    throw new NotImplementedException($"Unexpected value {placement} of the {nameof(PopupPlacement)} property inside the {nameof(ComboBoxPopup)} control.");
             }
         }
 
@@ -356,7 +356,7 @@ namespace MaterialDesignThemes.Wpf
         }
 
         private static CustomPopupPlacement GetDownPopupPlacement(PositioningData data)
-        {            
+        {
             return new CustomPopupPlacement(new Point(data.OffsetX, data.NewDownY), PopupPrimaryAxis.None);
         }
 

--- a/MaterialDesignThemes.Wpf/Screen.cs
+++ b/MaterialDesignThemes.Wpf/Screen.cs
@@ -8,12 +8,11 @@ using System.Windows;
 
 namespace MaterialDesignThemes.Wpf
 {
-
     ///<summary>
     /// Represents a display device or multiple display devices on a single system.
     /// Based on http://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Screen.cs
     /// </summary>
-    public class Screen
+    internal class Screen
     {
         private static class NativeMethods
         {


### PR DESCRIPTION
Requested changes after PR #685 was merged.

Fixing issue where combo box would revert back to classic mode on right monitor to the right of the primary screen.

Made Screen class internal. Initially I just took all of the code for this class from Windows Forms. However you don't want this as part of the API, there are many methods in there that are not being used and could be stripped out if desired.