### PR TITLE
PasswordBox hint alignment

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -50,6 +50,7 @@
                                                FloatingScale="{Binding Path=(wpf:HintAssist.FloatingScale), RelativeSource={RelativeSource TemplatedParent}}"
                                                FloatingOffset="{Binding Path=(wpf:HintAssist.FloatingOffset), RelativeSource={RelativeSource TemplatedParent}}"  
                                                FontSize="{TemplateBinding FontSize}"
+                                               Padding="{TemplateBinding Padding}"
                                                />
                             </Grid>
                         </Border>


### PR DESCRIPTION
Fixes #718 

Adding template binding to Password Text Box so the hint properly aligns.