### PR TITLE
Fix Thumb of GridViewColumnHeader.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -87,9 +87,6 @@
             <Setter.Value>
                 <ControlTemplate TargetType="GridViewColumnHeader">
                     <DockPanel>
-                        <Thumb x:Name="PART_HeaderGripper"
-                               DockPanel.Dock="Right"
-                               Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />
                         <Border x:Name="HeaderBorder"
                                 Padding="{TemplateBinding Padding}"
                                 BorderThickness="{TemplateBinding BorderThickness}">
@@ -101,6 +98,10 @@
                                               SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
 
                         </Border>
+                        <Thumb x:Name="PART_HeaderGripper"
+                               Margin="0,0,-8,0"
+                               DockPanel.Dock="Right"
+                               Style="{StaticResource MaterialDesignGridColumnHeaderGripper}" />
                     </DockPanel>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
@@ -143,7 +144,7 @@
         <Setter Property="BorderBrush" Value="Transparent" />
         <Setter Property="Template">
             <Setter.Value>
-                <ControlTemplate TargetType="ListBoxItem">
+                <ControlTemplate TargetType="ListViewItem">
                     <Border x:Name="Border"
                             Padding="{Binding RelativeSource={RelativeSource Self}, Path=(wpf:ListViewAssist.ListViewItemPadding)}"
                             Background="{TemplateBinding Background}"


### PR DESCRIPTION
I found GridViewColumnHeader bug.
Thumb can not be selected if the column area narrows.
I adjusted Thumb's Margin.