### PR TITLE
Fix a minor bug in MainDemo.wpf

### DIFF
--- a/MainDemo.Wpf/IconPackViewModel.cs
+++ b/MainDemo.Wpf/IconPackViewModel.cs
@@ -63,7 +63,7 @@ namespace MaterialDesignDemo
         private void CopyToClipboard(object obj)
         {
             var kind = (PackIconKind?)obj;
-            Clipboard.SetText($"<materialDesign:PackIcon Kind=\"{kind}\" />");
+            Clipboard.SetDataObject($"<materialDesign:PackIcon Kind=\"{kind}\" />");
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/MainDemo.Wpf/IconPackViewModel.cs
+++ b/MainDemo.Wpf/IconPackViewModel.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using MaterialDesignColors.WpfExample;
 using MaterialDesignColors.WpfExample.Domain;
 using MaterialDesignThemes.Wpf;
 
@@ -63,7 +64,9 @@ namespace MaterialDesignDemo
         private void CopyToClipboard(object obj)
         {
             var kind = (PackIconKind?)obj;
-            Clipboard.SetDataObject($"<materialDesign:PackIcon Kind=\"{kind}\" />");
+            string toBeCopied = $"<materialDesign:PackIcon Kind=\"{kind}\" />";
+            Clipboard.SetDataObject(toBeCopied);
+            MainWindow.Snackbar.MessageQueue.Enqueue(toBeCopied + " is copied to clipboard!");
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/MainDemo.Wpf/MainWindow.xaml.cs
+++ b/MainDemo.Wpf/MainWindow.xaml.cs
@@ -13,8 +13,8 @@ namespace MaterialDesignColors.WpfExample
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
-    {
+    public partial class MainWindow : Window {
+        public static Snackbar Snackbar;
         public MainWindow()
         {
             InitializeComponent();            
@@ -30,6 +30,8 @@ namespace MaterialDesignColors.WpfExample
                 //need to get the message queue from the snackbar, so need to be on the dispatcher
                 MainSnackbar.MessageQueue.Enqueue("Welcome to Material Design In XAML Tookit");
             }, TaskScheduler.FromCurrentSynchronizationContext());
+
+            Snackbar = this.MainSnackbar;
         }        
 
         private void UIElement_OnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)


### PR DESCRIPTION
Bug : Clicking the "Copy to clipboard" button in IconPackView will cause an exception to be thrown.
Now the bug is fixed. 
Solution is based on StackOverflow answers : 
[https://stackoverflow.com/questions/12769264/openclipboard-failed-when-copy-pasting-data-from-wpf-datagrid](url)