### PR TITLE
Fixed GetUsePopup & SetUsePopup in ValidationAssist

### DIFF
--- a/MaterialDesignThemes.Wpf/ValidationAssist.cs
+++ b/MaterialDesignThemes.Wpf/ValidationAssist.cs
@@ -45,12 +45,12 @@ namespace MaterialDesignThemes.Wpf
 
         public static bool GetUsePopup(DependencyObject element)
         {
-            return (bool)element.GetValue(OnlyShowOnFocusProperty);
+            return (bool)element.GetValue(UsePopupProperty);
         }
 
         public static void SetUsePopup(DependencyObject element, bool value)
         {
-            element.SetValue(OnlyShowOnFocusProperty, value);
+            element.SetValue(UsePopupProperty, value);
         }
 
         #endregion


### PR DESCRIPTION
Points the `ValidationAssist.GetUsePopup` and `ValidationAssist.SetUsePopup` to the correct property.

Appears to be a copy/paste error.