### PR TITLE
Fix combo box background while popup is open.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -476,6 +476,9 @@
             <Trigger SourceName="PART_Popup" Property="PopupPlacement" Value="{x:Static materialdesign:ComboBoxPopupPlacement.Classic}">
                 <Setter Property="ItemContainerStyle" Value="{StaticResource MaterialDesignComboBoxItemStyle}" />
             </Trigger>
+            <Trigger SourceName="PART_Popup" Property="IsOpen" Value="True">
+                <Setter Property="Background" TargetName="templateRoot" Value="{Binding Background, ElementName=PART_Popup}" />
+            </Trigger>
             <Trigger Property="IsEnabled" Value="False">
                 <Setter TargetName="templateRoot" Property="Opacity" Value="0.56"/>
             </Trigger>


### PR DESCRIPTION
The "hole" in the combo box template is painfully obvious when the background on the window is a non-solid color brush. When the combobox is open set the background to match the popup. This "hides" the hole by making it match the color that the popup using.

Relates to #630 #584