### PR TITLE
Implemented StaysOpenProperty for DrawerHost

### DIFF
--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -7,7 +7,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <materialDesign:DrawerHost Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
+    <materialDesign:DrawerHost x:Name="DrawerHost" Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
         <materialDesign:DrawerHost.LeftDrawerContent>
             <StackPanel Margin="16">
                 <TextBlock Margin="4" HorizontalAlignment="Center">LEFT FIELD</TextBlock>
@@ -78,6 +78,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
@@ -109,7 +110,12 @@
                         Style="{DynamicResource MaterialDesignRaisedAccentButton}">
                     <materialDesign:PackIcon Kind="ArrowAll" />
                 </Button>
+                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
+                    <TextBlock>Stays open </TextBlock>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                </StackPanel>
             </Grid>
         </Grid>
     </materialDesign:DrawerHost>
 </UserControl>
+

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -112,7 +112,7 @@
                 </Button>
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
                     <TextBlock>Stays open </TextBlock>
-                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,6 +78,15 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
+        public bool StaysOpen 
+        {
+            get { return (bool)GetValue(StaysOpenProperty); }
+            set { SetValue(StaysOpenProperty , value); }
+        }
+
+        public static readonly DependencyProperty StaysOpenProperty =
+            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+
         #region top drawer
 
         public static readonly DependencyProperty TopDrawerContentProperty = DependencyProperty.Register(
@@ -424,8 +433,9 @@ namespace MaterialDesignThemes.Wpf
                 PrepareZIndexes(BottomDrawerZIndexPropertyKey);
         }
 
-        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
+            if (StaysOpen) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,14 +78,14 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
-        public bool StaysOpen 
+        public bool CloseOnClickAway 
         {
-            get { return (bool)GetValue(StaysOpenProperty); }
-            set { SetValue(StaysOpenProperty , value); }
+            get { return (bool)GetValue(CloseOnClickAwayProperty); }
+            set { SetValue(CloseOnClickAwayProperty , value); }
         }
 
-        public static readonly DependencyProperty StaysOpenProperty =
-            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+        public static readonly DependencyProperty CloseOnClickAwayProperty =
+            DependencyProperty.Register("CloseOnClickAway" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(true));
 
         #region top drawer
 
@@ -435,7 +435,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (StaysOpen) return;
+            if (!CloseOnClickAway) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);


### PR DESCRIPTION
- Currently, I needed this property for my project, because I am using DrawerHost as an error reporting mechanism, so I needed a behavior where the drawer will not be closed even if user clicks outside of it.
- Although by setting the `IsEnabled = false` can achieve the same behavior, but it also disabled all the controls in the drawers, therefore I needed the StaysOpenProperty on DrawerHost
- Please do take a look at an example usage : 
![image](https://user-images.githubusercontent.com/23183656/29977436-e9bcc6f0-8f6f-11e7-8e9f-c5888bff5252.png)
In this scenario, I need the *Group-Clashing* hyperlink to be clickable by the user, but at the same time I also wants to disable user from closing it by clicking outside of the drawer.

