### PR TITLE
Add CloseOnClickAway property for drawer host

### DIFF
--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -7,7 +7,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <materialDesign:DrawerHost x:Name="DrawerHost" Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
+    <materialDesign:DrawerHost x:Name="DrawerHost" Margin="64" HorizontalAlignment="Stretch" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
         <materialDesign:DrawerHost.LeftDrawerContent>
             <StackPanel Margin="16">
                 <TextBlock Margin="4" HorizontalAlignment="Center">LEFT FIELD</TextBlock>
@@ -105,14 +105,16 @@
                         Grid.Row="2" Grid.Column="1" Margin="4">
                     <materialDesign:PackIcon Kind="ArrowDown" />
                 </Button>
-                <Button Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
+                <Button x:Name="OpenAllDrawerButton" Command="{x:Static materialDesign:DrawerHost.OpenDrawerCommand}"
                         Grid.Row="1" Grid.Column="1" Margin="4" 
                         Style="{DynamicResource MaterialDesignRaisedAccentButton}">
                     <materialDesign:PackIcon Kind="ArrowAll" />
                 </Button>
-                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
-                    <TextBlock>Close on click away</TextBlock>
-                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
+                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
+                    <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
+                    <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
+                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
+                    <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -111,7 +111,7 @@
                     <materialDesign:PackIcon Kind="ArrowAll" />
                 </Button>
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
-                    <TextBlock>Stays open </TextBlock>
+                    <TextBlock>Close on click away</TextBlock>
                     <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
                 </StackPanel>
             </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -7,7 +7,7 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
-    <materialDesign:DrawerHost Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
+    <materialDesign:DrawerHost x:Name="DrawerHost" Margin="64" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="{DynamicResource MaterialDesignDivider}">
         <materialDesign:DrawerHost.LeftDrawerContent>
             <StackPanel Margin="16">
                 <TextBlock Margin="4" HorizontalAlignment="Center">LEFT FIELD</TextBlock>
@@ -78,6 +78,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
@@ -109,7 +110,12 @@
                         Style="{DynamicResource MaterialDesignRaisedAccentButton}">
                     <materialDesign:PackIcon Kind="ArrowAll" />
                 </Button>
+                <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
+                    <TextBlock>Stays open </TextBlock>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                </StackPanel>
             </Grid>
         </Grid>
     </materialDesign:DrawerHost>
 </UserControl>
+

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -22,6 +22,22 @@
                         Style="{DynamicResource MaterialDesignFlatButton}">
                     CLOSE ALL
                 </Button>
+                <ToggleButton
+                    Command="{x:Static materialDesign:DrawerHost.PinDrawerCommand}"
+                    VerticalAlignment="Center"
+                    Style="{StaticResource MaterialDesignSwitchToggleButton}"
+                    ToolTip="Pin this drawer">
+                    <materialDesign:PackIcon
+                        Kind="Pin"
+                        RenderTransformOrigin=".5,.5">
+                        <materialDesign:PackIcon.RenderTransform>
+                            <RotateTransform Angle="45" />
+                        </materialDesign:PackIcon.RenderTransform>
+                    </materialDesign:PackIcon>
+                    <materialDesign:ToggleButtonAssist.OnContent >
+                        <materialDesign:PackIcon Kind="Pin" />
+                    </materialDesign:ToggleButtonAssist.OnContent>
+                </ToggleButton>
             </StackPanel>
         </materialDesign:DrawerHost.LeftDrawerContent>
         <materialDesign:DrawerHost.TopDrawerContent>
@@ -113,7 +129,7 @@
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Column="0" Grid.Row="3" Grid.ColumnSpan="3">
                     <TextBlock FontWeight="Bold" Margin="0 8 0 8">Open mode:</TextBlock>
                     <RadioButton Checked="StandardRadioButton_OnChecked" IsChecked="True">Standard</RadioButton>
-                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open</RadioButton>
+                    <RadioButton Checked="StaysOpenRadioButton_OnChecked">Stays Open (it means drawer won't close on click away)</RadioButton>
                     <RadioButton Checked="PinnedRadioButton_OnChecked">Pinned</RadioButton>
                 </StackPanel>
             </Grid>

--- a/MainDemo.Wpf/Drawers.xaml
+++ b/MainDemo.Wpf/Drawers.xaml
@@ -112,7 +112,7 @@
                 </Button>
                 <StackPanel HorizontalAlignment="Center" Margin="5" Grid.Row="3" Grid.ColumnSpan="3" Orientation="Horizontal">
                     <TextBlock>Stays open </TextBlock>
-                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=StaysOpen}"></CheckBox>
+                    <CheckBox IsChecked="{Binding ElementName=DrawerHost, Path=CloseOnClickAway}"></CheckBox>
                 </StackPanel>
             </Grid>
         </Grid>

--- a/MainDemo.Wpf/Drawers.xaml.cs
+++ b/MainDemo.Wpf/Drawers.xaml.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -12,6 +13,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using MaterialDesignThemes.Wpf;
 
 namespace MaterialDesignDemo
 {
@@ -23,6 +25,21 @@ namespace MaterialDesignDemo
         public Drawers()
         {
             InitializeComponent();
+        }
+
+        private void StandardRadioButton_OnChecked(object sender, RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Standard;
+            OpenAllDrawerButton.IsEnabled = true;
+        }
+
+        private void StaysOpenRadioButton_OnChecked(object sender, RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.StaysOpen;
+            OpenAllDrawerButton.IsEnabled = true;
+        }
+
+        private void PinnedRadioButton_OnChecked(object sender , RoutedEventArgs e) {
+            DrawerHost.OpenMode = DrawerHost.DrawerHostOpenMode.Pinned;
+            OpenAllDrawerButton.IsEnabled = false;
         }
     }
 }

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -81,10 +81,7 @@ namespace MaterialDesignThemes.Wpf
         public enum DrawerHostOpenMode 
         {
             Standard, StaysOpen, Pinned
-            
         }
-
-
 
         public DrawerHostOpenMode OpenMode {
             get { return (DrawerHostOpenMode)GetValue(OpenModeProperty); }
@@ -448,7 +445,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (OpenMode == DrawerHostOpenMode.StaysOpen) return;
+            if (OpenMode != DrawerHostOpenMode.Standard) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -96,44 +96,34 @@ namespace MaterialDesignThemes.Wpf
 
         private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) {
             var drawerHost = dependencyObject as DrawerHost;
-            var newValue = (DrawerHostOpenMode) dependencyPropertyChangedEventArgs.NewValue;
-            if (newValue == DrawerHostOpenMode.Pinned) {
-                if (drawerHost.MoreThanOneDrawerOpened()) throw new Exception( "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
-                if (drawerHost.IsLeftDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(drawerHost._leftDrawerElement.ActualWidth, 0, 0, 0);
-                }
-                if (drawerHost.IsTopDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, drawerHost._topDrawerElement.ActualHeight, 0, 0);
-                }
-                if (drawerHost.IsRightDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, 0, drawerHost._rightDrawerElement.ActualWidth, 0);
-                }
-                if (drawerHost.IsBottomDrawerOpen) {
-                    drawerHost._mainContent.Margin = new Thickness(0, 0, 0, drawerHost._bottomDrawerElement.ActualHeight);
-                }
-            }
-            else {
-                drawerHost._mainContent.Margin = new Thickness(0 , 0 , 0 , 0);
-            }
             drawerHost.UpdateVisualStates();
         }
 
-        private FrameworkElement GetOpeningDrawer() {
-            if (IsLeftDrawerOpen) {
-                return _leftDrawerElement;
+        private void UpdateMainContentMargin() {
+            if (OpenMode == DrawerHostOpenMode.Pinned) {
+                if (MoreThanOneDrawerOpened())
+                    throw new Exception(
+                        "Cannot set OpenMode = Pinned when there are more than one drawers are opened.");
+                if (IsLeftDrawerOpen) {
+                    _mainContent.Margin = new Thickness(_leftDrawerElement.ActualWidth, 0, 0, 0);
+                }
+                else if (IsTopDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, _topDrawerElement.ActualHeight, 0, 0);
+                }
+                else if (IsRightDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, 0, _rightDrawerElement.ActualWidth, 0);
+                }
+                else if (IsBottomDrawerOpen) {
+                    _mainContent.Margin = new Thickness(0, 0, 0, _bottomDrawerElement.ActualHeight);
+                }
+                else {
+                    _mainContent.Margin = new Thickness(0, 0, 0, 0);
+                }
             }
-            if (IsTopDrawerOpen) {
-                return _topDrawerElement;
+            else {
+                _mainContent.Margin = new Thickness(0, 0, 0, 0);
             }
-            if (IsRightDrawerOpen) {
-                return _rightDrawerElement;
-            }
-            if (IsBottomDrawerOpen) {
-                return _bottomDrawerElement;
-            }
-            return null;
         }
-
         private bool MoreThanOneDrawerOpened() {
             int numberOfOpenedDrawer = 0;
             if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
@@ -502,16 +492,11 @@ namespace MaterialDesignThemes.Wpf
 
         private void UpdateVisualStates(bool? useTransitions = null)
         {
-            if (OpenMode == DrawerHostOpenMode.Pinned) {
-                VisualStateManager.GoToState(this, TemplateAllDrawersAllClosedStateName,
-                    useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
-                return;
-            }
-
             var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
+            UpdateMainContentMargin();
             
             VisualStateManager.GoToState(this,
-                !anyOpen ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
+                !anyOpen || OpenMode==DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));
 
             VisualStateManager.GoToState(this,
                 IsLeftDrawerOpen ? TemplateLeftOpenStateName : TemplateLeftClosedStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,14 +78,27 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
-        public bool CloseOnClickAway 
+        public enum DrawerHostOpenMode 
         {
-            get { return (bool)GetValue(CloseOnClickAwayProperty); }
-            set { SetValue(CloseOnClickAwayProperty , value); }
+            Standard, StaysOpen, Pinned
+            
         }
 
-        public static readonly DependencyProperty CloseOnClickAwayProperty =
-            DependencyProperty.Register("CloseOnClickAway" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(true));
+
+
+        public DrawerHostOpenMode OpenMode {
+            get { return (DrawerHostOpenMode)GetValue(OpenModeProperty); }
+            set { SetValue(OpenModeProperty , value); }
+        }
+
+        // Using a DependencyProperty as the backing store for OpenMode.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty OpenModeProperty =
+            DependencyProperty.Register("OpenMode" , typeof(DrawerHostOpenMode) , typeof(DrawerHost) , new PropertyMetadata(DrawerHostOpenMode.Standard, OnOpenModePropertyChangedCallback));
+
+        private static void OnOpenModePropertyChangedCallback(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs) 
+        {
+            throw new NotImplementedException();
+        }
 
         #region top drawer
 
@@ -435,7 +448,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (!CloseOnClickAway) return;
+            if (OpenMode == DrawerHostOpenMode.StaysOpen) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -138,6 +138,7 @@ namespace MaterialDesignThemes.Wpf
             }
             _mainContent.BeginAnimation(MarginProperty, thicknessAnimation);
         }
+
         private bool MoreThanOneDrawerOpened() {
             int numberOfOpenedDrawer = 0;
             if (IsLeftDrawerOpen) numberOfOpenedDrawer++;
@@ -506,8 +507,11 @@ namespace MaterialDesignThemes.Wpf
 
         private void UpdateVisualStates(bool? useTransitions = null)
         {
-            var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
+            if (OpenMode == DrawerHostOpenMode.Pinned && MoreThanOneDrawerOpened()) return;
+
             UpdateMainContentMargin();
+
+            var anyOpen = IsTopDrawerOpen || IsLeftDrawerOpen || IsBottomDrawerOpen || IsRightDrawerOpen;
             
             VisualStateManager.GoToState(this,
                 !anyOpen || OpenMode==DrawerHostOpenMode.Pinned ? TemplateAllDrawersAllClosedStateName : TemplateAllDrawersAnyOpenStateName, useTransitions.HasValue ? useTransitions.Value : !TransitionAssist.GetDisableTransitions(this));

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,6 +78,15 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
+        public bool StaysOpen 
+        {
+            get { return (bool)GetValue(StaysOpenProperty); }
+            set { SetValue(StaysOpenProperty , value); }
+        }
+
+        public static readonly DependencyProperty StaysOpenProperty =
+            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+
         #region top drawer
 
         public static readonly DependencyProperty TopDrawerContentProperty = DependencyProperty.Register(
@@ -424,8 +433,9 @@ namespace MaterialDesignThemes.Wpf
                 PrepareZIndexes(BottomDrawerZIndexPropertyKey);
         }
 
-        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs)
+        private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
+            if (StaysOpen) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -78,14 +78,14 @@ namespace MaterialDesignThemes.Wpf
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
         }
 
-        public bool StaysOpen 
+        public bool CloseOnClickAway 
         {
-            get { return (bool)GetValue(StaysOpenProperty); }
-            set { SetValue(StaysOpenProperty , value); }
+            get { return (bool)GetValue(CloseOnClickAwayProperty); }
+            set { SetValue(CloseOnClickAwayProperty , value); }
         }
 
-        public static readonly DependencyProperty StaysOpenProperty =
-            DependencyProperty.Register("StaysOpen" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(false));
+        public static readonly DependencyProperty CloseOnClickAwayProperty =
+            DependencyProperty.Register("CloseOnClickAway" , typeof(bool) , typeof(DrawerHost) , new PropertyMetadata(true));
 
         #region top drawer
 
@@ -435,7 +435,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void TemplateContentCoverElementOnPreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs mouseButtonEventArgs) 
         {
-            if (StaysOpen) return;
+            if (!CloseOnClickAway) return;
             SetCurrentValue(IsLeftDrawerOpenProperty, false);
             SetCurrentValue(IsRightDrawerOpenProperty, false);
             SetCurrentValue(IsTopDrawerOpenProperty, false);

--- a/MaterialDesignThemes.Wpf/DrawerHost.cs
+++ b/MaterialDesignThemes.Wpf/DrawerHost.cs
@@ -56,6 +56,7 @@ namespace MaterialDesignThemes.Wpf
 
         public static RoutedCommand OpenDrawerCommand = new RoutedCommand();
         public static RoutedCommand CloseDrawerCommand = new RoutedCommand();
+        public static RoutedCommand PinDrawerCommand = new RoutedCommand();
 
         private FrameworkElement _mainContent;
         private FrameworkElement _templateContentCoverElement;
@@ -83,6 +84,7 @@ namespace MaterialDesignThemes.Wpf
         {
             CommandBindings.Add(new CommandBinding(OpenDrawerCommand, OpenDrawerHandler));
             CommandBindings.Add(new CommandBinding(CloseDrawerCommand, CloseDrawerHandler));
+            CommandBindings.Add(new CommandBinding(PinDrawerCommand, PinDrawerHanlder));
         }
         #region openModeProperty
         public enum DrawerHostOpenMode 
@@ -604,6 +606,22 @@ namespace MaterialDesignThemes.Wpf
                     _lockZIndexes = false;
                 }
             }
+        }
+
+        private bool _pinned = false;
+        private DrawerHostOpenMode _previousMode;
+        private void PinDrawerHanlder(object sender , ExecutedRoutedEventArgs executedRoutedEventArgs) {
+            if (executedRoutedEventArgs.Handled) return;
+            if (!_pinned) {
+                _previousMode = OpenMode;
+                SetCurrentValue(OpenModeProperty, DrawerHostOpenMode.Pinned);
+                _pinned = true;
+            }
+            else {
+                SetCurrentValue(OpenModeProperty, _previousMode);
+                _pinned = false;
+            }
+            executedRoutedEventArgs.Handled = true;
         }
     }
 }


### PR DESCRIPTION
- Currently, I needed this property for my project, because I am using DrawerHost as an error reporting mechanism, so I needed a behavior where the drawer will not be closed even if user clicks outside of it.
- Although by setting the `IsEnabled = false` can achieve the same behavior, but it also disabled all the controls in the drawers, therefore I needed the CloseOnClickAway property on DrawerHost
- Please do take a look at an example usage : 
![image](https://user-images.githubusercontent.com/23183656/29977436-e9bcc6f0-8f6f-11e7-8e9f-c5888bff5252.png)
In this scenario, I need the *Group-Clashing* hyperlink to be clickable by the user, but at the same time I also wants to disable user from closing it by clicking outside of the drawer.

Not only that, I also need this CloseOnClickAway property because I uses DrawerHost for the following scenarios : 
1. As an alternative to dialog box, because in some situation using dialog box is too aggressive. 
2. To display progress bar while loading something and also disabling UI at the same time. 
