### PR TITLE
Intermediate progress bar stops animating

### DIFF
--- a/MaterialDesignThemes.Wpf/Converters/NotZeroConverter.cs
+++ b/MaterialDesignThemes.Wpf/Converters/NotZeroConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace MaterialDesignThemes.Wpf.Converters
+{
+    public class NotZeroConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (double.TryParse((value ?? "").ToString(), out double val))
+            {
+                return Math.Abs(val) > 0.0;
+            }
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
+++ b/MaterialDesignThemes.Wpf/MaterialDesignThemes.Wpf.csproj
@@ -281,6 +281,7 @@
     <Compile Include="Converters\ClockItemIsCheckedConverter.cs" />
     <Compile Include="Converters\ClockLineConverter.cs" />
     <Compile Include="Converters\ListViewItemContainerStyleConverter.cs" />
+    <Compile Include="Converters\NotZeroConverter.cs" />
     <Compile Include="Converters\RangeLengthConverter.cs" />
     <Compile Include="Converters\RangePositionConverterConverter.cs" />
     <Compile Include="Converters\DrawerOffsetConverter.cs" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ProgressBar.xaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:circularProgressBar="clr-namespace:MaterialDesignThemes.Wpf.Converters.CircularProgressBar"
-                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf"
-                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions">
+                    xmlns:transitions="clr-namespace:MaterialDesignThemes.Wpf.Transitions"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters">
     
     <Style x:Key="MaterialDesignLinearProgressBar" TargetType="{x:Type ProgressBar}">
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueDarkBrush}"/>
@@ -121,6 +121,7 @@
     <circularProgressBar:LargeArcConverter x:Key="LargeArcConverter" />
     <circularProgressBar:RotateTransformConverter x:Key="RotateTransformConverter" />
     <circularProgressBar:RotateTransformCentreConverter x:Key="RotateTransformCentreConverter" />
+    <converters:NotZeroConverter x:Key="NotZeroConverter" />
 
     <Style x:Key="MaterialDesignCircularProgressBar" TargetType="{x:Type ProgressBar}">
         <Setter Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
@@ -136,16 +137,16 @@
                         </Storyboard>
                         <Storyboard x:Key="IsFullyIndeterminateScaleStoryboard">
                             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="FullyIndeterminateGridScaleTransform"
-                                                                   Storyboard.TargetProperty="ScaleX"                                                      
-                                                                   RepeatBehavior="Forever">
+                                                           Storyboard.TargetProperty="ScaleX"
+                                                           RepeatBehavior="Forever">
                                 <SplineDoubleKeyFrame KeyTime="0" Value="0.0" />
                                 <SplineDoubleKeyFrame KeyTime="0:0:1" Value="1.0" />
                                 <SplineDoubleKeyFrame KeyTime="0:0:4" Value="0.0" />
                             </DoubleAnimationUsingKeyFrames>
                             <DoubleAnimation Storyboard.TargetName="RotateTransform"
-                                                     Storyboard.TargetProperty="Angle" 
-                                                     RepeatBehavior="Forever"
-                                                     From="00" To="359" Duration="0:0:1.25" />
+                                             Storyboard.TargetProperty="Angle" 
+                                             RepeatBehavior="Forever"
+                                             From="00" To="359" Duration="0:0:1.25" />
                         </Storyboard>
                     </ControlTemplate.Resources>
                     <Grid x:Name="TemplateRoot" ClipToBounds="False">
@@ -158,14 +159,13 @@
                         <Canvas>
                             <Ellipse Fill="{TemplateBinding Background}" Width="{TemplateBinding Width}" Height="{TemplateBinding Height}" />
                             <Path x:Name="Path" Stroke="{TemplateBinding Foreground}" StrokeThickness="3" 
-                                          Canvas.Top="2" Canvas.Left="2"
-                                          RenderTransformOrigin="0, 0">
+                                  Canvas.Top="2" Canvas.Left="2"
+                                  RenderTransformOrigin="0, 0">
                                 <Path.Data>
                                     <PathGeometry>
                                         <PathFigure StartPoint="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource StartPointConverter}, Mode=OneWay}">
-                                            <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}"                                                             
-                                                                SweepDirection="Clockwise"
-                                                                >
+                                            <ArcSegment Size="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource ArcSizeConverter}, Mode=OneWay}"
+                                                        SweepDirection="Clockwise">
                                                 <ArcSegment.IsLargeArc>
                                                     <MultiBinding Converter="{StaticResource LargeArcConverter}">
                                                         <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Value" />
@@ -190,8 +190,8 @@
                                 <Path.RenderTransform>
                                     <TransformGroup>
                                         <RotateTransform x:Name="RotateTransform"
-                                                                 CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}" 
-                                                                 CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}">
+                                                         CenterX="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}" 
+                                                         CenterY="{Binding ElementName=PathGrid, Path=ActualWidth, Converter={StaticResource RotateTransformCentreConverter}, Mode=OneWay}">
                                             <RotateTransform.Angle>
                                                 <MultiBinding Converter="{StaticResource RotateTransformConverter}">
                                                     <Binding RelativeSource="{RelativeSource TemplatedParent}" Path="Value" />
@@ -206,20 +206,21 @@
                         </Canvas>
                     </Grid>
                     <ControlTemplate.Triggers>
-                        <MultiTrigger>
-                            <MultiTrigger.Conditions>
-                                <Condition Property="IsIndeterminate" Value="True" />                                
-                                <Condition Property="IsVisible" Value="True" />
-                            </MultiTrigger.Conditions>
-                            <MultiTrigger.EnterActions>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsIndeterminate, RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding IsVisible, RelativeSource={RelativeSource Self}}" Value="True" />
+                                <Condition Binding="{Binding Value, RelativeSource={RelativeSource Self}, Converter={StaticResource NotZeroConverter}}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <MultiDataTrigger.EnterActions>
                                 <RemoveStoryboard BeginStoryboardName="IsFullyIndeterminateStoryboard" />
                                 <BeginStoryboard Storyboard="{StaticResource IsIndeterminateStoryboard}"
-                                                         Name="IsIndeterminateStoryboard"/>
-                            </MultiTrigger.EnterActions>
-                            <MultiTrigger.ExitActions>
+                                                 Name="IsIndeterminateStoryboard"/>
+                            </MultiDataTrigger.EnterActions>
+                            <MultiDataTrigger.ExitActions>
                                 <RemoveStoryboard BeginStoryboardName="IsIndeterminateStoryboard" />
-                            </MultiTrigger.ExitActions>
-                        </MultiTrigger>
+                            </MultiDataTrigger.ExitActions>
+                        </MultiDataTrigger>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
                                 <Condition Property="IsIndeterminate" Value="True" />
@@ -229,7 +230,7 @@
                             <MultiTrigger.EnterActions>
                                 <RemoveStoryboard BeginStoryboardName="IsIndeterminateStoryboard" />
                                 <BeginStoryboard Storyboard="{StaticResource IsFullyIndeterminateScaleStoryboard}"
-                                                         Name="IsFullyIndeterminateStoryboard"/>
+                                                 Name="IsFullyIndeterminateStoryboard"/>
                             </MultiTrigger.EnterActions>
                             <MultiTrigger.ExitActions>
                                 <RemoveStoryboard BeginStoryboardName="IsFullyIndeterminateStoryboard" />


### PR DESCRIPTION
Fixes #790 

This was a really interesting one to fix.
The issue is that the triggers were not mutually exclusive.

So given the use case of an indeterminate progress bar whose vlaue starts at 0 and is then changed to non-zero the execution looks like this:

I will call the first trigger IndeterminateTrigger (the one I changed) and the second one FullyIndeterminateTrigger. 

1. Progress bar loaded
2. IndeterminateTrigger matches
3. IndeterminateTrigger enter action removes IsFullyIndeterminateStoryboard
4. IndeterminateTrigger enter action begins IsIndeterminateStoryboard
5. FullyIndeterminateTrigger matches
6. FullyIndeterminateTrigger enter action removes IsIndeterminateStoryboard
7. FullyIndeterminateTrigger enter action begins IsFullyIndeterminateScaleStoryboard
... some time passes allowing for meditation, throwing something at the co-worker who broke the build, or that extra drink of coffee ...
8. The progress bar's value property changes to a non-zero value
9. FullyIndeterminateTrigger enter action removes IsFullyIndeterminateScaleStoryboard

Because the IndeterminateTrigger was previously matched it is not matched a second time.
This is also why toggling the IsIndeterminate value will "kick" the progress bar back into moving.

In short the fix is to make the triggers mutually exclusive so only one is matched at any given time.