### PR TITLE
Keyboard tab now ignores the Expander header

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.Expander.xaml
@@ -274,6 +274,8 @@
                         </VisualStateManager.VisualStateGroups>
                         <DockPanel Background="{TemplateBinding Background}">
                             <ToggleButton Name="HeaderSite"
+                                          Focusable="False"
+                                          IsTabStop="False"
                                               DockPanel.Dock="Top"
                                               BorderThickness="0" Cursor="Hand"
                                               IsChecked="{Binding Path=IsExpanded, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"


### PR DESCRIPTION
In the current `Expander` style, the header consists of two parts: the header text button and the header arrow button. Whenever a click event happens on any of these, the `Expander` opens. When navigating with the tab (via the keyboard), the following happens (expander of the left):

![Current tabbing](https://i.gyazo.com/76bad64d7c556dbf189730b6e978d808.gif)

... that is, to navigate past an `Expander`, tab needs to be pressed twice. I believe it would make a lot more sense for only the arrow button to grab focus and show a focus visual style. The change I made results in the following look:

![New tab focus](https://i.gyazo.com/d86850a6070034e349eb14f307aed189.gif)
