### PR TITLE
Fix #758 - hyperlink to DialogViewModel should now work

### DIFF
--- a/MainDemo.Wpf/Domain/MainWindowViewModel.cs
+++ b/MainDemo.Wpf/Domain/MainWindowViewModel.cs
@@ -163,7 +163,7 @@ namespace MaterialDesignColors.WpfExample.Domain
                     {
                         DocumentationLink.WikiLink("Dialogs", "Dialogs"),
                         DocumentationLink.DemoPageLink<Dialogs>("Demo View"),
-                        DocumentationLink.DemoPageLink<DialogsViewModel>("Demo View Model"),
+                        DocumentationLink.DemoPageLink<DialogsViewModel>("Demo View Model", "Domain"),
                         DocumentationLink.ApiLink<DialogHost>()
                     }),
                 new DemoItem("Drawer", new Drawers(),


### PR DESCRIPTION
The `DialogViewModel.cs` class is located under the `Domain` namespace, but the hyperlink was targeting the root folder. The link should now work.