### PR TITLE
Fix hyperlink to the contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To load the source project you will need Visual Studio 2017.  Don't worry if you
 
 # ![Alt text](web/images/MD4XAML28.png "Contributions") Contribution Guidelines
 
-* Before contributing code read the [Contribution Guidelines](CONTRIBUTING.md)
+* Before contributing code read the [Contribution Guidelines](.github/CONTRIBUTING.md)
   * GitHub issues are for bugs.
   * For queries, help, and general chat stop by the [Gitter chat room](https://gitter.im/ButchersBoy/MaterialDesignInXamlToolkit).
   * Stack Overflow tag: [material-design-in-xaml](http://stackoverflow.com/questions/tagged/material-design-in-xaml)


### PR DESCRIPTION
The link to the contribution guidelines was going to a 404. As the file is inside the .github folder, I've added the folder name to the path.