### PR TITLE
Fixes #820 - Opacity of the old transition slide should now always be set to 0

### DIFF
--- a/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
+++ b/MaterialDesignThemes.Wpf/Transitions/Transitioner.cs
@@ -197,17 +197,23 @@ namespace MaterialDesignThemes.Wpf.Transitions
             }
 
             if (newSlide != null)
-                newSlide.Opacity = 1;                
+            {
+                newSlide.Opacity = 1;
+            }
+                          
             if (oldSlide != null && newSlide != null)
             {
                 var wipe = selectedIndex > unselectedIndex ? oldSlide.ForwardWipe : oldSlide.BackwardWipe;
-                if (wipe != null)                
-                    wipe.Wipe(oldSlide, newSlide, GetTransitionOrigin(newSlide), this);                
+                if (wipe != null)
+                {
+                    wipe.Wipe(oldSlide, newSlide, GetTransitionOrigin(newSlide), this);
+                }
                 else
                 {
                     DoStack(newSlide, oldSlide);
-                    oldSlide.Opacity = 0;
                 }
+
+                oldSlide.Opacity = 0;
             }
             else if (oldSlide != null || newSlide != null)
             {


### PR DESCRIPTION
Hopefully this fixes #820 under all circumstances. Previously, the old slide's opacity was only being set to 0 under very specific circumstances, rather than every time. With this change, the behaviour changes to:

![slides-being-hidden](https://i.gyazo.com/4a815e17383107eeffe1fcc05396957e.gif)

rather than what was demonstrated in #820 

![slides-not-being-hidden](https://i.gyazo.com/1116b25f56a709abfc3d78aa0c24f92d.gif)

