### PR TITLE
Bump version in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,9 @@
   assembly_info:
     patch: true
     file: '**\AssemblyInfo.*'
-    assembly_version: '2.3.1.{build}'
-    assembly_file_version: '2.3.1.{build}'
-    assembly_informational_version: '2.3.1.{build}'
+    assembly_version: '2.3.2.{build}'
+    assembly_file_version: '2.3.2.{build}'
+    assembly_informational_version: '2.3.2.{build}'
   environment:
     RestorePackages: false
   before_build:
@@ -25,7 +25,7 @@
   - path: '**\MaterialDesignThemes.*.nupkg'
   - path: bin\**\*.*
 
-  version: 2.3.1-ci{build}
+  version: 2.3.2-ci{build}
   deploy:
   - provider: NuGet
     api_key:
@@ -58,4 +58,4 @@
   - path: '**\MaterialDesignThemes.*.nupkg'
   - path: bin\**\*.*
 
-  version: 2.3.1.{build}
+  version: 2.3.2.{build}


### PR DESCRIPTION
Right now CI builds are coming through as 2.3.1-ci<build number>. Because of [version ordering](https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages) this causes them to not appear as prerelease updates to the current 2.3.1 release.