### PR TITLE
Fix NullReferenceException in ListBoxAssist

### DIFF
--- a/MaterialDesignThemes.Wpf/ListBoxAssist.cs
+++ b/MaterialDesignThemes.Wpf/ListBoxAssist.cs
@@ -27,6 +27,8 @@ namespace MaterialDesignThemes.Wpf
             var point = mouseButtonEventArgs.GetPosition(senderElement);
             var result = VisualTreeHelper.HitTest(senderElement, point);
 
+            if (result == null) return;
+
             ListBoxItem listBoxItem = null;
             Ripple ripple = null;
             foreach (var dependencyObject in result.VisualHit.GetVisualAncestry().TakeWhile(_ => listBoxItem == null))


### PR DESCRIPTION
Clicking near the edge of a control that uses ListBoxAssist, creates an NullReferenceException, because VisualTreeHelper.HitTest may return null in that case.

