### PR TITLE
Defaulting CanContentScroll to be true to fix data virtualization.

### DIFF
--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml
@@ -10,6 +10,7 @@
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="{x:Static GridView.GridViewScrollViewerStyleKey}" TargetType="{x:Type ScrollViewer}">
+        <Setter Property="CanContentScroll" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ScrollViewer}">
@@ -227,7 +228,6 @@
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="FontSize" Value="13" />
         <Setter Property="ItemContainerStyle" Value="{Binding RelativeSource={RelativeSource Self}, Path=View, Converter={StaticResource MaterialDesignListViewItemContainerStyleConverter}}" />
-        <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
         <Setter Property="ScrollViewer.PanningMode" Value="Both" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="SnapsToDevicePixels" Value="True" />


### PR DESCRIPTION
There was a bug report in gitter chat about the DrawerHost being slow when processing lots of items.  It turned out the issue was the DrawerHost was wrapping a ListView with a large number of item. Rather than defaulting to having virtualization turned on, it was defaulting [CanContentScroll](https://docs.microsoft.com/en-us/dotnet/api/system.windows.controls.scrollviewer.cancontentscroll) to be false [disabling virtualization](https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/optimizing-performance-controls) by default. The default [WPF template](https://docs.microsoft.com/en-us/dotnet/framework/wpf/controls/listview-styles-and-templates) blindly sets the the CanContentScroll property to be true. The MDIX template [sets it using a TemplateBinding](https://github.com/ButchersBoy/MaterialDesignInXamlToolkit/blob/master/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListView.xaml#L51). The problem is the property's default value is false.

So the fix is to leave the template binding, but add a setter to default the property to `true`.

The removal of the setter in the ListView style is because it is a duplicate.

 