### PR TITLE
Update SmartHint styles to better match the material design specifica…

### DIFF
--- a/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
+++ b/MaterialDesignThemes.Wpf/HintProxyFabric.ComboBox.cs
@@ -26,6 +26,7 @@ namespace MaterialDesignThemes.Wpf
                 _comboBox.SelectionChanged += ComboBoxSelectionChanged;
                 _comboBox.Loaded += ComboBoxLoaded;
                 _comboBox.IsVisibleChanged += ComboBoxIsVisibleChanged;
+                _comboBox.IsKeyboardFocusWithinChanged += ComboBoxIsKeyboardFocusWithinChanged;
             }
 
             public object Content
@@ -48,16 +49,16 @@ namespace MaterialDesignThemes.Wpf
 
             public bool IsVisible => _comboBox.IsVisible;            
 
-            public bool IsEmpty()
-            {
-                return string.IsNullOrEmpty(_comboBox.Text);
-            }
+            public bool IsEmpty() => string.IsNullOrEmpty(_comboBox.Text);
+
+            public bool IsFocused() => _comboBox.IsEditable && _comboBox.IsKeyboardFocusWithin;
 
             public event EventHandler ContentChanged;
 
             public event EventHandler IsVisibleChanged;
 
             public event EventHandler Loaded;
+            public event EventHandler FocusedChanged;
 
             private void ComboBoxSelectionChanged(object sender, SelectionChangedEventArgs e)
             {
@@ -79,12 +80,18 @@ namespace MaterialDesignThemes.Wpf
                 ContentChanged?.Invoke(sender, EventArgs.Empty);
             }
 
+            private void ComboBoxIsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
+            {
+                FocusedChanged?.Invoke(sender, EventArgs.Empty);
+            }
+
             public void Dispose()
             {
                 _comboBox.RemoveHandler(TextBoxBase.TextChangedEvent, _comboBoxTextChangedEventHandler);
                 _comboBox.Loaded -= ComboBoxLoaded;
                 _comboBox.IsVisibleChanged -= ComboBoxIsVisibleChanged;
-                _comboBox.SelectionChanged -= ComboBoxSelectionChanged;
+                _comboBox.SelectionChanged -= ComboBoxSelectionChanged;                
+                _comboBox.IsKeyboardFocusWithinChanged -= ComboBoxIsKeyboardFocusWithinChanged;
             }
         }
     }

--- a/MaterialDesignThemes.Wpf/HintProxyFabric.PasswordBox.cs
+++ b/MaterialDesignThemes.Wpf/HintProxyFabric.PasswordBox.cs
@@ -17,9 +17,12 @@ namespace MaterialDesignThemes.Wpf
 
             public bool IsVisible => _passwordBox.IsVisible;
 
+            public bool IsFocused() => _passwordBox.IsKeyboardFocused;
+
             public event EventHandler ContentChanged;
             public event EventHandler IsVisibleChanged;
             public event EventHandler Loaded;
+            public event EventHandler FocusedChanged;
 
             public PasswordBoxHintProxy(PasswordBox passwordBox)
             {
@@ -29,6 +32,12 @@ namespace MaterialDesignThemes.Wpf
                 _passwordBox.PasswordChanged += PasswordBoxPasswordChanged;
                 _passwordBox.Loaded += PasswordBoxLoaded;
                 _passwordBox.IsVisibleChanged += PasswordBoxIsVisibleChanged;
+                _passwordBox.IsKeyboardFocusedChanged += PasswordBoxIsKeyboardFocusedChanged;
+            }
+
+            private void PasswordBoxIsKeyboardFocusedChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
+            {
+                FocusedChanged?.Invoke(this, EventArgs.Empty);
             }
 
             private void PasswordBoxIsVisibleChanged(object sender, System.Windows.DependencyPropertyChangedEventArgs e)
@@ -51,6 +60,7 @@ namespace MaterialDesignThemes.Wpf
                 _passwordBox.PasswordChanged -= PasswordBoxPasswordChanged;
                 _passwordBox.Loaded -= PasswordBoxLoaded;
                 _passwordBox.IsVisibleChanged -= PasswordBoxIsVisibleChanged;
+                _passwordBox.IsKeyboardFocusedChanged -= PasswordBoxIsKeyboardFocusedChanged;
             }
 
         }

--- a/MaterialDesignThemes.Wpf/HintProxyFabric.TextBox.cs
+++ b/MaterialDesignThemes.Wpf/HintProxyFabric.TextBox.cs
@@ -18,9 +18,12 @@ namespace MaterialDesignThemes.Wpf
 
             public bool IsEmpty() => string.IsNullOrEmpty(_textBox.Text);
 
+            public bool IsFocused() => _textBox.IsKeyboardFocused;
+
             public event EventHandler ContentChanged;
             public event EventHandler IsVisibleChanged;
             public event EventHandler Loaded;
+            public event EventHandler FocusedChanged;
 
             public TextBoxHintProxy(TextBox textBox)
             {
@@ -30,6 +33,12 @@ namespace MaterialDesignThemes.Wpf
                 _textBox.TextChanged += TextBoxTextChanged;
                 _textBox.Loaded += TextBoxLoaded;
                 _textBox.IsVisibleChanged += TextBoxIsVisibleChanged;
+                _textBox.IsKeyboardFocusedChanged += TextBoxIsKeyboardFocusedChanged;
+            }
+
+            private void TextBoxIsKeyboardFocusedChanged(object sender, DependencyPropertyChangedEventArgs e)
+            {
+                FocusedChanged?.Invoke(sender, EventArgs.Empty);
             }
 
             private void TextBoxIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -52,6 +61,7 @@ namespace MaterialDesignThemes.Wpf
                 _textBox.TextChanged -= TextBoxTextChanged;
                 _textBox.Loaded -= TextBoxLoaded;
                 _textBox.IsVisibleChanged -= TextBoxIsVisibleChanged;
+                _textBox.IsKeyboardFocusedChanged -= TextBoxIsKeyboardFocusedChanged;
             }
         }
     }

--- a/MaterialDesignThemes.Wpf/IHintProxy.cs
+++ b/MaterialDesignThemes.Wpf/IHintProxy.cs
@@ -21,6 +21,12 @@ namespace MaterialDesignThemes.Wpf
         /// <returns></returns>
         bool IsEmpty();
 
+        /// <summary>
+        /// Targeted control has keyboard focus
+        /// </summary>
+        /// <returns></returns>
+        bool IsFocused();
+
         [Obsolete]
         object Content { get; }
 
@@ -33,5 +39,7 @@ namespace MaterialDesignThemes.Wpf
         event EventHandler IsVisibleChanged;
 
         event EventHandler Loaded;
+
+        event EventHandler FocusedChanged;
     }
 }

--- a/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media.Animation;
 using MaterialDesignThemes.Wpf.Converters;
 
 namespace MaterialDesignThemes.Wpf
@@ -17,15 +16,13 @@ namespace MaterialDesignThemes.Wpf
     /// <para/>
     /// To set a target control you should set the HintProxy property. Use the <see cref="HintProxyFabricConverter.Instance"/> converter which converts a control into the IHintProxy interface.
     /// </summary>
-    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = ContentEmptyName)]
-    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = ContentNotEmptyName)]
+    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintRestingPositionName)]
+    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintFloatingPositionName)]
     public class SmartHint : Control
     {        
         public const string ContentStatesGroupName = "ContentStates";
-        public const string ContentEmptyName = "ContentEmpty";
-        public const string ContentNotEmptyName = "ContentNotEmpty";
-
-        private ContentControl _floatingHintPart = null;
+        public const string HintRestingPositionName = "HintRestingPosition";
+        public const string HintFloatingPositionName = "HintFloatingPosition";
 
         #region ManagedProperty
 
@@ -67,6 +64,24 @@ namespace MaterialDesignThemes.Wpf
         {
             get { return (bool) GetValue(IsContentNullOrEmptyProperty); }
             private set { SetValue(IsContentNullOrEmptyPropertyKey, value); }
+        }
+
+        #endregion
+
+        #region IsHintInFloatingPosition
+
+        private static readonly DependencyPropertyKey IsHintInFloatingPositionPropertyKey =
+            DependencyProperty.RegisterReadOnly(
+                "IsHintInFloatingPosition", typeof(bool), typeof(SmartHint),
+                new PropertyMetadata(default(bool)));
+
+        public static readonly DependencyProperty IsHintInFloatingPositionProperty =
+            IsHintInFloatingPositionPropertyKey.DependencyProperty;
+
+        public bool IsHintInFloatingPosition
+        {
+            get { return (bool)GetValue(IsHintInFloatingPositionProperty); }
+            private set { SetValue(IsHintInFloatingPositionPropertyKey, value); }
         }
 
         #endregion
@@ -143,6 +158,7 @@ namespace MaterialDesignThemes.Wpf
                 hintProxy.IsVisibleChanged -= smartHint.OnHintProxyIsVisibleChanged;
                 hintProxy.ContentChanged -= smartHint.OnHintProxyContentChanged;
                 hintProxy.Loaded -= smartHint.OnHintProxyContentChanged;
+                hintProxy.FocusedChanged -= smartHint.OnHintProxyFocusedChanged;
                 hintProxy.Dispose();
             }
 
@@ -152,7 +168,16 @@ namespace MaterialDesignThemes.Wpf
             hintProxy.IsVisibleChanged += smartHint.OnHintProxyIsVisibleChanged;
             hintProxy.ContentChanged += smartHint.OnHintProxyContentChanged;
             hintProxy.Loaded += smartHint.OnHintProxyContentChanged;
+            hintProxy.FocusedChanged += smartHint.OnHintProxyFocusedChanged;
             smartHint.RefreshState(false);
+        }
+
+        protected virtual void OnHintProxyFocusedChanged(object sender, EventArgs e)
+        {
+            if (HintProxy.IsLoaded)
+                RefreshState(true);
+            else
+                HintProxy.Loaded += HintProxySetStateOnLoaded;
         }
 
         protected virtual void OnHintProxyContentChanged(object sender, EventArgs e)
@@ -160,13 +185,9 @@ namespace MaterialDesignThemes.Wpf
             IsContentNullOrEmpty = HintProxy.IsEmpty();
 
             if (HintProxy.IsLoaded)
-            {
                 RefreshState(true);
-            }
-            else
-            {
+            else            
                 HintProxy.Loaded += HintProxySetStateOnLoaded;
-            }
         }
 
         private void HintProxySetStateOnLoaded(object sender, EventArgs e)
@@ -182,20 +203,26 @@ namespace MaterialDesignThemes.Wpf
 
         private void RefreshState(bool useTransitions)
         {
-            var proxy = HintProxy;
+            IHintProxy proxy = HintProxy;
 
             if (proxy == null) return;
             if (!proxy.IsVisible) return;
             
             var action = new Action(() =>
             {
-                var isEmpty = proxy.IsEmpty();
+                string state = string.Empty;
 
-                var state = isEmpty
-                    ? ContentEmptyName
-                    : ContentNotEmptyName;
-            
-                VisualStateManager.GoToState(this, state, useTransitions);                
+                bool isEmpty = proxy.IsEmpty();
+                bool isFocused = proxy.IsFocused();
+
+                if (UseFloating)
+                    state = !isEmpty || isFocused ? HintFloatingPositionName : HintRestingPositionName;
+                else
+                    state = !isEmpty ? HintFloatingPositionName : HintRestingPositionName;
+
+                IsHintInFloatingPosition = state == HintFloatingPositionName;
+
+                VisualStateManager.GoToState(this, state, useTransitions);
             });
 
             if (DesignerProperties.GetIsInDesignMode(this))

--- a/MaterialDesignThemes.Wpf/SmartHint.cs
+++ b/MaterialDesignThemes.Wpf/SmartHint.cs
@@ -16,11 +16,18 @@ namespace MaterialDesignThemes.Wpf
     /// <para/>
     /// To set a target control you should set the HintProxy property. Use the <see cref="HintProxyFabricConverter.Instance"/> converter which converts a control into the IHintProxy interface.
     /// </summary>
+    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = ContentEmptyName)]
+    [TemplateVisualState(GroupName = ContentStatesGroupName, Name = ContentNotEmptyName)]
     [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintRestingPositionName)]
     [TemplateVisualState(GroupName = ContentStatesGroupName, Name = HintFloatingPositionName)]
     public class SmartHint : Control
     {        
         public const string ContentStatesGroupName = "ContentStates";
+        [System.Obsolete]
+        public const string ContentEmptyName = "ContentEmpty";
+        [System.Obsolete]
+        public const string ContentNotEmptyName = "ContentNotEmpty";
+
         public const string HintRestingPositionName = "HintRestingPosition";
         public const string HintFloatingPositionName = "HintFloatingPosition";
 

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ComboBox.xaml
@@ -501,7 +501,17 @@
             <MultiTrigger>
                 <MultiTrigger.Conditions>
                     <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
-                    <Condition Property="IsKeyboardFocused" Value="True" />
+                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                    <Condition Property="IsKeyboardFocusWithin" Value="True" />
+                </MultiTrigger.Conditions>
+                <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
+                <Setter TargetName="Hint" Property="HintOpacity" Value="1" />
+            </MultiTrigger>
+            <MultiTrigger>
+                <MultiTrigger.Conditions>
+                    <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
+                    <Condition SourceName="Hint" Property="IsHintInFloatingPosition" Value="True" />
+                    <Condition Property="IsKeyboardFocusWithin" Value="True" />
                 </MultiTrigger.Conditions>
                 <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />
                 <Setter TargetName="Hint" Property="HintOpacity" Value="1" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.PasswordBox.xaml
@@ -59,7 +59,7 @@
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                                 <Condition Property="IsKeyboardFocused" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.SmartHint.xaml
@@ -26,13 +26,13 @@
                         <VisualStateManager.VisualStateGroups>
                             <VisualStateGroup x:Name="ContentStates">
                                 <VisualStateGroup.Transitions>
-                                    <VisualTransition From="*" To="ContentNotEmpty">
+                                    <VisualTransition From="*" To="HintFloatingPosition">
                                         <Storyboard>
                                             <DoubleAnimation Storyboard.TargetName="SimpleHintTextBlock" Storyboard.TargetProperty="Opacity"
                                                              Duration="0:0:0" To="0" />
                                         </Storyboard>
                                     </VisualTransition>
-                                    <VisualTransition From="*" To="ContentEmpty">
+                                    <VisualTransition From="*" To="HintRestingPosition">
                                         <Storyboard>
                                             <DoubleAnimation Storyboard.TargetName="SimpleHintTextBlock" Storyboard.TargetProperty="Opacity"
                                                              Duration="0:0:0.3"
@@ -40,13 +40,13 @@
                                         </Storyboard>
                                     </VisualTransition>
                                 </VisualStateGroup.Transitions>
-                                <VisualState x:Name="ContentNotEmpty">
+                                <VisualState x:Name="HintFloatingPosition">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="SimpleHintTextBlock"
                                                          Duration="0" To="0" />
                                     </Storyboard>
                                 </VisualState>
-                                <VisualState x:Name="ContentEmpty">
+                                <VisualState x:Name="HintRestingPosition">
                                     <Storyboard>
                                         <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="SimpleHintTextBlock"
                                                          Duration="0" />
@@ -78,7 +78,7 @@
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="ContentStates">
                                         <VisualStateGroup.Transitions>
-                                            <VisualTransition From="*" To="ContentNotEmpty">
+                                            <VisualTransition From="*" To="HintFloatingPosition">
                                                 <Storyboard>
                                                     <DoubleAnimation Storyboard.TargetName="FloatingHintTextBlock" Storyboard.TargetProperty="Opacity"
                                                                      Duration="0:0:0.3" To="{TemplateBinding HintOpacity}"
@@ -88,7 +88,7 @@
                                                                      EasingFunction="{StaticResource AnimationEasingFunction}"/>
                                                 </Storyboard>
                                             </VisualTransition>
-                                            <VisualTransition From="*" To="ContentEmpty">
+                                            <VisualTransition From="*" To="HintRestingPosition">
                                                 <Storyboard>
                                                     <DoubleAnimation Storyboard.TargetName="FloatingHintTextBlock" Storyboard.TargetProperty="Opacity"
                                                                      Duration="0:0:0.3"
@@ -99,7 +99,7 @@
                                                 </Storyboard>
                                             </VisualTransition>
                                         </VisualStateGroup.Transitions>
-                                        <VisualState x:Name="ContentNotEmpty">
+                                        <VisualState x:Name="HintFloatingPosition">
                                             <Storyboard>
                                                 <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="FloatingHintTextBlock"
                                                                  Duration="0" To="{TemplateBinding HintOpacity}" />
@@ -107,7 +107,7 @@
                                                                  Duration="0" To="1"/>
                                             </Storyboard>
                                         </VisualState>
-                                        <VisualState x:Name="ContentEmpty">
+                                        <VisualState x:Name="HintRestingPosition">
                                             <Storyboard>
                                                 <DoubleAnimation Storyboard.TargetProperty="Opacity" Storyboard.TargetName="FloatingHintTextBlock"
                                                                  Duration="0" />

--- a/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
+++ b/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.TextBox.xaml
@@ -86,7 +86,7 @@
                     <ControlTemplate.Triggers>
                         <MultiTrigger>
                             <MultiTrigger.Conditions>
-                                <Condition SourceName="Hint" Property="IsContentNullOrEmpty" Value="False" />
+                                <Condition Property="wpf:HintAssist.IsFloating" Value="True" />
                                 <Condition Property="IsKeyboardFocused" Value="True" />
                             </MultiTrigger.Conditions>
                             <Setter TargetName="Hint" Property="Foreground" Value="{DynamicResource PrimaryHueMidBrush}" />


### PR DESCRIPTION
Hello again,

I have updated the SmartHint styles to better match the design specification. For example, when using floating hints and the control is focused (and editable), the hint is now immediately raised and colored.

![image](https://user-images.githubusercontent.com/32176237/32417062-6bd3824e-c221-11e7-9569-0cc7e570a1c4.png)

![image](https://user-images.githubusercontent.com/32176237/32417066-836ed5d4-c221-11e7-935c-77ea4c4ab2fd.png)


